### PR TITLE
Trigger non-streamdump eiger gridscan recipe

### DIFF
--- a/mimas/core.py
+++ b/mimas/core.py
@@ -204,6 +204,17 @@ def run(
                 )
             )
 
+        elif scenario.beamline in ("i03", "i04", "i24"):
+            if (
+                scenario.detectorclass == dlstbx.mimas.MimasDetectorClass.EIGER
+                and scenario.isitagridscan
+            ):
+                tasks.append(
+                    dlstbx.mimas.MimasRecipeInvocation(
+                        DCID=scenario.DCID, recipe="per-image-analysis-eiger-gridscan"
+                    )
+                )
+
         elif scenario.beamline == "i02-2":
             # VMXi is also a special case
             ishdf = "#" in "dcid[image_pattern]"  # I guess this is exactly wrong


### PR DESCRIPTION
This is to workaround ongoing issues with the eiger streamdump route
observed on I03 and I04. Leave the eiger streamdump trigger in, to
allow debugging of the issue in the meantime. The streamdump and
non-streamdump eiger recipes can be edited more trivially to switch
between the approaches as necessary.