### PR TITLE
Change directory path generation

### DIFF
--- a/ispybtbx/__init__.py
+++ b/ispybtbx/__init__.py
@@ -666,7 +666,9 @@ WHERE
         return visit_base.group(2)
 
     def dc_info_to_working_directory(self, dc_info):
-        directory = dc_info["imageDirectory"]
+        directory = dc_info.get("imageDirectory")
+        if not directory:
+            return None
         visit = self.get_visit_directory_from_image_directory(directory)
         rest = directory[len(visit) + 1 :]
 
@@ -679,7 +681,9 @@ WHERE
         )
 
     def dc_info_to_results_directory(self, dc_info):
-        directory = dc_info["imageDirectory"]
+        directory = dc_info.get("imageDirectory")
+        if not directory:
+            return None
         visit = self.get_visit_directory_from_image_directory(directory)
         rest = directory[len(visit) + 1 :]
 

--- a/ispybtbx/test_ispyb.py
+++ b/ispybtbx/test_ispyb.py
@@ -59,10 +59,10 @@ def test_ispyb_recipe_filtering_does_read_datacollection_information():
     assert parameters["ispyb_visit"] == "cm14451-4"
     assert parameters["ispyb_visit_directory"] == "/dls/i03/data/2016/cm14451-4"
     assert parameters["ispyb_results_directory"].startswith(
-        "/dls/i03/data/2016/cm14451-4/processed/tmp/2016-10-07/fake113556/TRP_M1S6_4_/"
+        "/dls/i03/data/2016/cm14451-4/processed/tmp/2016-10-07/fake113556/TRP_M1S6_4/"
     )
     assert parameters["ispyb_working_directory"].startswith(
-        "/dls/i03/data/2016/cm14451-4/tmp/zocalo/tmp/2016-10-07/fake113556/TRP_M1S6_4_"
+        "/dls/i03/data/2016/cm14451-4/tmp/zocalo/tmp/2016-10-07/fake113556/TRP_M1S6_4/"
     )
 
     non_ispyb_parameters = {
@@ -75,6 +75,7 @@ def test_ispyb_recipe_filtering_is_successful_for_all_listed_examples():
     for example, dcid in ds.items():
         message = {}
         parameters = {"ispyb_dcid": dcid}
+        print(f"{example}: {dcid}")
         message, parameters = ispyb_filter(message, parameters)
         assert message == {"default_recipe": mock.ANY}
         assert len(parameters) > 10


### PR DESCRIPTION
This is about `ispyb_working_directory` and `ispyb_results_directory`.

Currently we generate these paths from ISPyB material by taking the `imageDirectory`, splicing in either `processed/` or `tmp/zocalo/` as appropriate, then add a directory based on the `fileTemplate`, shaving off the bit beyond the final underscore, and finally adding a unique ID.

For example:
```
$ dlstbx.find_in_ispyb 5646074
'dataCollectionNumber': 1
'fileTemplate': '3-3_1_master.h5'
'imageDirectory': '/dls/i04/data/2020/mx21426-77/guido/screening/TRIM28/'
'imagePrefix': '3-3'
'ispyb_results_directory': '/dls/i04/data/2020/mx21426-77/processed/guido/screening/TRIM28/3-3_1_/2d286aa7-01d4-4999-9e44-4986de3848ad'
'ispyb_working_directory': '/dls/i04/data/2020/mx21426-77/tmp/zocalo/guido/screening/TRIM28/3-3_1_/2d286aa7-01d4-4999-9e44-4986de3848ad'
```
It turns out in EM we don't have a useful file template, and no guarantee that `fileTemplate` even contains an underscore.

I was therefore thinking about changing how the path is generated. Because we could also take
`imageDirectory.head` / extra path / `imageDirectory.tail` / `imagePrefix` + `_` + `dataCollectionNumber` / `uuid`
(with `imageDirectory.head` being the visit directory and `.tail` being the path component to the images)
which would be more well defined for EM, and should make no difference for MX.

