### PR TITLE
Use swmr-pia for I03/I24 rotation scans

### DIFF
--- a/src/dlstbx/mimas/core.py
+++ b/src/dlstbx/mimas/core.py
@@ -520,7 +520,10 @@ def run(
                 )
             )
 
-            if scenario.beamline not in SWMR_BEAMLINES:
+            if (
+                scenario.dcclass == dlstbx.mimas.MimasDCClass.ROTATION
+                and scenario.beamline not in SWMR_BEAMLINES
+            ):
                 # Only trigger rotation PIA at end of data collection for
                 # non-SWMR EIGER beamlines
                 tasks.append(


### PR DESCRIPTION
For I03 and I24 trigger the per-image-analysis-rotation-swmr recipe at the start of collection, rather than the legacy pia recipe at the
end of data collection.
No longer trigger streamdump recipe for swmr beamlines (avoids warnings appearing in graylog).