### PR TITLE
Verify HDF5 files are 1.10 version

### DIFF
--- a/src/dlstbx/util/hdf5.py
+++ b/src/dlstbx/util/hdf5.py
@@ -45,3 +45,23 @@ def find_all_references(startfile):
             else:
                 image_count[filename] += shape[0]
     return image_count
+
+
+def is_readable(filename: str) -> bool:
+    """Check if a file can be read"""
+
+    try:
+        with h5py.File(filename, "r"):
+            return True
+    except Exception:
+        return False
+
+
+def is_HDF_1_8_compatible(filename: str) -> bool:
+    """Check if a file can be read with HDF 1.8. This excludes all SWMR formatted files."""
+
+    try:
+        with h5py.File(filename, "r", libver=("earliest", "v108")):
+            return True
+    except OSError:
+        return False


### PR DESCRIPTION
Fixes https://jira.diamond.ac.uk/browse/SCI-9671

Verify that the files given are in HDF5 1.10 format but not compatible with 1.8 which would indicate that they are written with SWMR compatibility. 