### PR TITLE
We should fail if the file _is_ 1.8 format

### DIFF
--- a/src/dlstbx/services/validation.py
+++ b/src/dlstbx/services/validation.py
@@ -89,7 +89,7 @@ class DLSValidation(CommonService):
             hdf_18 = [
                 link
                 for link in hdf5_util.find_all_references(filename)
-                if not hdf5_util.is_HDF_1_8_compatible(link)
+                if hdf5_util.is_HDF_1_8_compatible(link)
             ]
             if hdf_18:
                 return fail(


### PR DESCRIPTION
Fixes https://jira.diamond.ac.uk/browse/SCI-9730

I think we had the logic of the list filtering wrong, test failed on https://ispyb.diamond.ac.uk/dc/visit/cm28182-2/id/6140426 when it should not have done. 