### PR TITLE
Trigger service: construct sqlalchemy engine once

### DIFF
--- a/requirements.conda.txt
+++ b/requirements.conda.txt
@@ -9,6 +9,7 @@ procrunner>=1.0.2
 pytest
 pytest-mock
 pyyaml
+sqlalchemy>=1.4.0,<1.5
 stomp.py
 workflows>=2.0
 xmltodict

--- a/src/dlstbx/services/trigger.py
+++ b/src/dlstbx/services/trigger.py
@@ -1,4 +1,3 @@
-import contextlib
 import hashlib
 import logging
 import os
@@ -28,23 +27,11 @@ from ispyb.sqlalchemy import (
 )
 
 
-_sessionfactory = sqlalchemy.orm.sessionmaker(
+Session = sqlalchemy.orm.sessionmaker(
     bind=sqlalchemy.create_engine(
         ispyb.sqlalchemy.url(), connect_args={"use_pure": True}
     )
 )
-
-
-@contextlib.contextmanager
-def Session():
-    """Provide a transactional scope around a series of operations."""
-    # From sqlalchemy 1.4 Session and sessionmaker have full context
-    # manager support
-    session = _sessionfactory()
-    try:
-        yield session
-    finally:
-        session.close()
 
 
 class DLSTrigger(CommonService):
@@ -1056,6 +1043,10 @@ class DLSTrigger(CommonService):
                 for dc, app, pj in query.all():
                     # Select only those dcids at the same wavelength as the triggering dcid
                     if wavelength and dc.wavelength != wavelength:
+                        self.log.debug(
+                            f"Discarding appid {app.autoProcProgramId} (wavelength does not match input):\n"
+                            f"    {dc.wavelength} != {wavelength}"
+                        )
                         continue
 
                     # If this multiplex job was triggered with a spacegroup parameter

--- a/src/dlstbx/test/conftest.py
+++ b/src/dlstbx/test/conftest.py
@@ -2,9 +2,11 @@
 import os
 import ispyb.sqlalchemy
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def testconfig():
     """Return the path to a configuration file pointing to a test database."""
     config_file = os.getenv("ISPYB_TEST_CREDENTIALS")
@@ -22,10 +24,26 @@ def testdb(testconfig):
         yield conn
 
 
-@pytest.fixture
-def alchemy(testconfig):
-    session = ispyb.sqlalchemy.session(testconfig)
-    try:
-        yield session
-    finally:
-        session.close()
+@pytest.fixture(scope="session")
+def db_engine(testconfig):
+    """Yields a SQLAlchemy engine"""
+    engine = create_engine(
+        ispyb.sqlalchemy.url(testconfig), connect_args={"use_pure": True}
+    )
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture(scope="session")
+def db_session_factory(db_engine):
+    """Returns a SQLAlchemy scoped session factory"""
+    return sessionmaker(bind=db_engine)
+
+
+@pytest.fixture(scope="function")
+def db_session(db_session_factory):
+    """Yields a SQLAlchemy connection which is rollbacked after the test"""
+    session_ = db_session_factory()
+    yield session_
+    session_.rollback()
+    session_.close()


### PR DESCRIPTION
* construct sqlalchemy engine and session factory once on module
import
* create a new session that reuses this engine every time
we need it
* use new ispyb.sqlalchemy.url()
* require ispyb>=6.0.2