### PR TITLE
Only check for hdf 1.8 if file contains images

### DIFF
--- a/src/dlstbx/services/validation.py
+++ b/src/dlstbx/services/validation.py
@@ -88,8 +88,8 @@ class DLSValidation(CommonService):
                 )
             hdf_18 = [
                 link
-                for link in hdf5_util.find_all_references(filename)
-                if hdf5_util.is_HDF_1_8_compatible(link)
+                for link, image_count in hdf5_util.find_all_references(filename).items()
+                if image_count and hdf5_util.is_HDF_1_8_compatible(link)
             ]
             if hdf_18:
                 return fail(


### PR DESCRIPTION
The master file is still written in hdf 1.8 format, but shouldn't contain any images, therefore we don't care about that as far as
this check is concerned.