### PR TITLE
Remove references to default_recipe

### DIFF
--- a/src/dlstbx/cli/find_in_ispyb.py
+++ b/src/dlstbx/cli/find_in_ispyb.py
@@ -154,8 +154,6 @@ def run():
                     f.write(json_str)
         else:
             pprint.pprint(parameters)
-        if message.get("default_recipe"):
-            print("Default recipes:", ", ".join(sorted(message["default_recipe"])))
         print(
             "Synchweb: https://ispyb.diamond.ac.uk/dc/visit/{0[ispyb_visit]}/id/{0[ispyb_dcid]}".format(
                 parameters

--- a/src/dlstbx/ispybtbx/__init__.py
+++ b/src/dlstbx/ispybtbx/__init__.py
@@ -840,24 +840,14 @@ def ispyb_filter(message, parameters):
         return message, parameters
 
     if dc_class["grid"]:
-        if parameters["ispyb_beamline"] == "i02-2":
-            message["default_recipe"] = ["archive-nexus", "vmxi-spot-counts-per-image"]
-        else:
-            message["default_recipe"] = ["per-image-analysis-gridscan"]
         return message, parameters
 
     if dc_class["screen"]:
-        message["default_recipe"] = [
-            "per-image-analysis-rotation",
-            "strategy-edna",
-            "strategy-mosflm",
-        ]
         parameters["ispyb_images"] = ""
         return message, parameters
 
     if not dc_class["rotation"]:
         # possibly EM dataset
-        message["default_recipe"] = []
         return message, parameters
 
     # for the moment we do not want multi-xia2 for /dls/mx i.e. VMXi
@@ -896,29 +886,6 @@ def ispyb_filter(message, parameters):
                 )
 
             parameters["ispyb_images"] = ",".join(related_images)
-
-    message["default_recipe"] = [
-        "per-image-analysis-rotation",
-        "processing-autoproc",
-        "processing-fast-dp",
-        "processing-rlv",
-        "processing-xia2-3dii",
-        "processing-xia2-dials",
-    ]
-
-    if parameters["ispyb_beamline"] == "i02-2":
-        message["default_recipe"] = [
-            "archive-nexus",
-            "processing-autoproc",
-            "processing-fast-dp",
-            "processing-xia2-3dii",
-            "processing-xia2-dials",
-            "vmxi-per-image-analysis",
-        ]
-
-    if parameters["ispyb_images"]:
-        message["default_recipe"].append("processing-multi-xia2-dials")
-        message["default_recipe"].append("processing-multi-xia2-3dii")
 
     return message, parameters
 

--- a/src/dlstbx/ispybtbx/test_ispyb.py
+++ b/src/dlstbx/ispybtbx/test_ispyb.py
@@ -32,15 +32,7 @@ def test_ispyb_recipe_filtering_does_read_datacollection_information():
 
     message, parameters = ispyb_filter(message, parameters)
 
-    assert message == {"dummy_msg": mock.sentinel.dummy_msg, "default_recipe": mock.ANY}
-    for service in [
-        "per-image-analysis-rotation",
-        "processing-fast-dp",
-        "processing-xia2-3dii",
-        "processing-xia2-dials",
-        "processing-autoproc",
-    ]:
-        assert service in message["default_recipe"]
+    assert message == {"dummy_msg": mock.sentinel.dummy_msg}
     assert parameters["ispyb_beamline"] == "i03"
     assert parameters["ispyb_dcid"] == ds["gphl_C2"]
     assert isinstance(parameters["ispyb_dc_class"], dict)
@@ -76,7 +68,7 @@ def test_ispyb_recipe_filtering_is_successful_for_all_listed_examples():
         parameters = {"ispyb_dcid": dcid}
         print(f"{example}: {dcid}")
         message, parameters = ispyb_filter(message, parameters)
-        assert message == {"default_recipe": mock.ANY}
+        assert message == {}
         assert len(parameters) > 10
 
 


### PR DESCRIPTION
This is now superceded by mimas, and I believe these are no longer used anywhere.