### PR TITLE
ISPyB EM - Movie

### DIFF
--- a/src/dlstbx/services/ispybsvc_em.py
+++ b/src/dlstbx/services/ispybsvc_em.py
@@ -56,8 +56,7 @@ class EM_Mixin:
         db_session,
     ):
         self.log.info(
-            f"Looking for Motion Correction ID."
-            f"Micrograph name: {micrographname} APPID: {autoproc_program_id}"
+            f"Looking for Motion Correction ID. Micrograph name: {micrographname} APPID: {autoproc_program_id}"
         )
         mc_query = db_session.query(MotionCorrection).filter(
             MotionCorrection.micrographFullPath == micrographname,


### PR DESCRIPTION
Filter SQLAlchemy queries to find MotionCorrection ID.
Initially it seemed that Movie entries had to be inserted to do this, I now think that that was incorrect.