### PR TITLE
Dummy insert particle picking for ISPyB service

### DIFF
--- a/src/dlstbx/services/ispybsvc_em.py
+++ b/src/dlstbx/services/ispybsvc_em.py
@@ -105,19 +105,27 @@ class EM_Mixin:
 
         appid = parameters("program_id")
         dcid = parameters("dcid")
-        self.log.info(f"Would insert particle picker parameters. AutoProcProgramID: {appid}, DCID: {dcid}")
+        self.log.info(
+            f"Would insert particle picker parameters. AutoProcProgramID: {appid}, DCID: {dcid}"
+        )
         return {"success": True, "return_value": None}
 
     def do_insert_class2d(self, parameters, **kwargs):
         # This gives some output we can read from; ISPyB doesn't have fields for Class 2D yet
 
+        appid = parameters("program_id")
         dcid = parameters("dcid")
-        self.log.info(f"Would insert Class 2D parameters. DCID: {dcid}")
+        self.log.info(
+            f"Would insert Class 2D parameters. AutoProcProgramID: {appid}, DCID: {dcid}"
+        )
         return {"success": True, "return_value": None}
 
     def do_insert_class3d(self, parameters, **kwargs):
         # This gives some output we can read from; ISPyB doesn't have fields for Class 3D yet
 
+        appid = parameters("program_id")
         dcid = parameters("dcid")
-        self.log.info(f"Would insert Class 3D parameters. DCID: {dcid}")
+        self.log.info(
+            f"Would insert Class 3D parameters. AutoProcProgramID: {appid}, DCID: {dcid}"
+        )
         return {"success": True, "return_value": None}


### PR DESCRIPTION
Add a dummy `do_insert_particle_picker` method. This just logs a message and returns a success if called. This should stop potential future crashes when the Relion wrapper will be sending messages for insertion into the `ParticlePicker` table. 

I have also changed the dummy insert methods for 2D and 3D classification stages to refer to parameters that should be available (I think they currently refer to parameter keys that do not exist in the message sent to the ISPyB service by the Relion recipe).