### PR TITLE
Remove use_sample_id for Therm_6 definition

### DIFF
--- a/src/dlstbx/dc_sim/definitions.py
+++ b/src/dlstbx/dc_sim/definitions.py
@@ -301,7 +301,6 @@ tests = {
         "src_dir": "/dls/i04/data/2019/cm23004-1/20190214/gw-edna-test/Thermolysin/Therm_6",
         "src_run_num": (2,),
         "src_prefix": ("Therm_6",),
-        "use_sample_id": 1976283,
         "results": {
             "a": approx(100, abs=100),
             "b": approx(100, abs=100),


### PR DESCRIPTION
I don't think the sample_id is relevant since it links to a thermolysin `Protein` entry (and this is apparently thaumatin, despite the name) which means that any downstream dimple/mrbump jobs fail anyway. A side effect of linking to an existing sample_id is that we end up triggering a xia2.multiplex job with 951 (and counting) prior datasets associated with this sample.