### PR TITLE
Update EDNA wrapper to allow it to be run with Python 3

### DIFF
--- a/src/dlstbx/wrapper/edna.py
+++ b/src/dlstbx/wrapper/edna.py
@@ -200,7 +200,7 @@ module load {edna_module}
         params["image_pattern"] = prefix + "%04d.cbf"
         logger.info("Image pattern: %s", params["image_pattern"])
         logger.info(
-            "Converting %s to %s" % (master_h5, tmpdir / (params["image_pattern"]))
+            "Converting %s to %s", master_h5, tmpdir / (params["image_pattern"])
         )
         result = procrunner.run(
             ["dxtbx.dlsnxs2cbf", master_h5, params["image_pattern"]],


### PR DESCRIPTION
* Don't import EDNA python modules directly
  Doing so prevents us from running this wrapper with Python 3, and we no longer actively support the DIALS Python 2 installation, which prevents us from deploying updates to the wrapper. Generating the html report isn't that useful anyway, since there is no way for users to access it via SynchWeb (see SCI-9564).

* Write beheaded images to temporary_directory, c.f. what we already do for hdf5_to_cbf

* Use pathlib instead of py.path
