### PR TITLE
Use selectinload instead of joinedload

### DIFF
--- a/src/dlstbx/ispybtbx/__init__.py
+++ b/src/dlstbx/ispybtbx/__init__.py
@@ -11,7 +11,7 @@ import ispyb.sqlalchemy as isa
 import marshmallow.fields
 import sqlalchemy
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
-from sqlalchemy.orm import Load, aliased, joinedload, sessionmaker
+from sqlalchemy.orm import Load, aliased, joinedload, sessionmaker, selectinload
 
 
 logger = logging.getLogger("dlstbx.ispybtbx")
@@ -117,10 +117,13 @@ class ispybtbx:
                 query = (
                     session.query(isa.ProcessingJob)
                     .options(
-                        joinedload(isa.ProcessingJob.ProcessingJobParameters),
-                        joinedload(
-                            isa.ProcessingJob.ProcessingJobImageSweeps
-                        ).joinedload(isa.ProcessingJobImageSweep.DataCollection),
+                        selectinload(isa.ProcessingJob.ProcessingJobParameters),
+                        selectinload(isa.ProcessingJob.ProcessingJobImageSweeps)
+                        .selectinload(isa.ProcessingJobImageSweep.DataCollection)
+                        .load_only(
+                            isa.DataCollection.imageDirectory,
+                            isa.DataCollection.fileTemplate,
+                        ),
                     )
                     .filter(isa.ProcessingJob.processingJobId == reprocessing_id)
                 )


### PR DESCRIPTION
`joinedload` can be inefficient for large collections as every column of the parent object is repeated for every row of the collection. Using `selectin` load appears to be much more efficient in this case, as the number of data collections associated with a single `ProcessingJob` can potentially be large (many hundreds) for a `xia2.multiplex` job.

See also:
  https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html#what-kind-of-loading-to-use