### PR TITLE
EM table inserts that use the Zocalo buffer table

### DIFF
--- a/src/dlstbx/services/ispybsvc_em.py
+++ b/src/dlstbx/services/ispybsvc_em.py
@@ -215,6 +215,16 @@ class EM_Mixin:
             return False
 
     def do_insert_particle_picker(self, *, parameters, session, **kwargs):
+        # We don't yet have a way of inserting information from this message
+
+        appid = parameters("program_id")
+        dcid = parameters("dcid")
+        self.log.info(
+            f"Would insert particle picker parameters. AutoProcProgramID: {appid}, DCID: {dcid}"
+        )
+        return {"success": True, "return_value": None}
+
+    def do_insert_particle_picker_buffer(self, *, parameters, session, **kwargs):
 
         dcid = parameters("dcid")
         self.log.info(f"Inserting Particle Picker parameters. DCID: {dcid}")


### PR DESCRIPTION
With the buffer table the EM inserts can now be simplified to just having a `do_insert*` per table. The old methods are kept for now to enable a roll-out that won't compromise Relion pipeline instances running with an older `python-relion` version.