### PR TITLE
Mimas support for I19 Eiger data

### DIFF
--- a/src/dlstbx/mimas/core.py
+++ b/src/dlstbx/mimas/core.py
@@ -22,7 +22,7 @@ def run(
 
     if scenario.event is dlstbx.mimas.MimasEvent.START:
         if scenario.beamline in ("i19-1", "i19-2"):
-            # i19 is a special case
+            # I19 is a special case
             if scenario.detectorclass is dlstbx.mimas.MimasDetectorClass.PILATUS:
                 tasks.append(
                     dlstbx.mimas.MimasRecipeInvocation(
@@ -141,7 +141,10 @@ def run(
                     dlstbx.mimas.MimasISPyBJobInvocation(
                         DCID=scenario.DCID,
                         autostart=True,
-                        recipe="autoprocessing-multi-xia2-smallmolecule",
+                        recipe="autoprocessing-multi-xia2-smallmolecule"
+                        if scenario.detectorclass
+                        is dlstbx.mimas.MimasDetectorClass.PILATUS
+                        else "autoprocessing-multi-xia2-smallmolecule-nexus",
                         source="automatic",
                         sweeps=tuple(scenario.getsweepslistfromsamedcg),
                         parameters=(
@@ -154,7 +157,10 @@ def run(
                     dlstbx.mimas.MimasISPyBJobInvocation(
                         DCID=scenario.DCID,
                         autostart=True,
-                        recipe="autoprocessing-multi-xia2-smallmolecule-dials-aiml",
+                        recipe="autoprocessing-multi-xia2-smallmolecule-dials-aiml"
+                        if scenario.detectorclass
+                        is dlstbx.mimas.MimasDetectorClass.PILATUS
+                        else "autoprocessing-multi-xia2-smallmolecule-dials-aiml-nexus",
                         source="automatic",
                         sweeps=tuple(scenario.getsweepslistfromsamedcg),
                         parameters=symmetry_parameters,
@@ -165,7 +171,9 @@ def run(
                 dlstbx.mimas.MimasISPyBJobInvocation(
                     DCID=scenario.DCID,
                     autostart=True,
-                    recipe="autoprocessing-multi-xia2-smallmolecule",
+                    recipe="autoprocessing-multi-xia2-smallmolecule"
+                    if scenario.detectorclass is dlstbx.mimas.MimasDetectorClass.PILATUS
+                    else "autoprocessing-multi-xia2-smallmolecule-nexus",
                     source="automatic",
                     sweeps=tuple(scenario.getsweepslistfromsamedcg),
                     parameters=xia2_dials_absorption_params,
@@ -175,7 +183,9 @@ def run(
                 dlstbx.mimas.MimasISPyBJobInvocation(
                     DCID=scenario.DCID,
                     autostart=True,
-                    recipe="autoprocessing-multi-xia2-smallmolecule-dials-aiml",
+                    recipe="autoprocessing-multi-xia2-smallmolecule-dials-aiml"
+                    if scenario.detectorclass is dlstbx.mimas.MimasDetectorClass.PILATUS
+                    else "autoprocessing-multi-xia2-smallmolecule-dials-aiml-nexus",
                     source="automatic",
                     sweeps=tuple(scenario.getsweepslistfromsamedcg),
                 )

--- a/src/dlstbx/test/mimas/test_core.py
+++ b/src/dlstbx/test/mimas/test_core.py
@@ -344,14 +344,14 @@ def test_vmxi_rotation(anomalous_scatterer, absorption_level):
 
 
 @pytest.mark.parametrize(
-    "detectorclass, pia_type, data_format",
+    "detectorclass, pia_type, xia2_type, data_format",
     [
-        (MimasDetectorClass.PILATUS, "", "cbfs"),
-        (MimasDetectorClass.EIGER, "-swmr", "nexus"),
+        (MimasDetectorClass.PILATUS, "", "", "cbfs"),
+        (MimasDetectorClass.EIGER, "-swmr", "-nexus", "nexus"),
     ],
     ids=("Pilatus", "Eiger"),
 )
-def test_i19_rotation(detectorclass, pia_type, data_format):
+def test_i19_rotation(detectorclass, pia_type, xia2_type, data_format):
     """Test the I19 rotation scenario."""
     dcid = 6356546
     other_dcid = 6356585
@@ -380,7 +380,7 @@ def test_i19_rotation(detectorclass, pia_type, data_format):
                 "--new",
                 f"--dcid={dcid}",
                 "--source=automatic",
-                "--recipe=autoprocessing-multi-xia2-smallmolecule",
+                f"--recipe=autoprocessing-multi-xia2-smallmolecule{xia2_type}",
                 f"--add-sweep={dcid}:1:850",
                 f"--add-sweep={other_dcid}:1:850",
                 "--add-param=absorption_level:medium",
@@ -393,7 +393,7 @@ def test_i19_rotation(detectorclass, pia_type, data_format):
                 "--new",
                 f"--dcid={dcid}",
                 "--source=automatic",
-                "--recipe=autoprocessing-multi-xia2-smallmolecule-dials-aiml",
+                f"--recipe=autoprocessing-multi-xia2-smallmolecule-dials-aiml{xia2_type}",
                 f"--add-sweep={dcid}:1:850",
                 f"--add-sweep={other_dcid}:1:850",
                 "--trigger",
@@ -407,14 +407,14 @@ def test_i19_rotation(detectorclass, pia_type, data_format):
 
 
 @pytest.mark.parametrize(
-    "detectorclass, pia_type, data_format",
+    "detectorclass, pia_type, xia2_type, data_format",
     [
-        (MimasDetectorClass.PILATUS, "", "cbfs"),
-        (MimasDetectorClass.EIGER, "-swmr", "nexus"),
+        (MimasDetectorClass.PILATUS, "", "", "cbfs"),
+        (MimasDetectorClass.EIGER, "-swmr", "-nexus", "nexus"),
     ],
     ids=("Pilatus", "Eiger"),
 )
-def test_i19_rotation_with_symmetry(detectorclass, pia_type, data_format):
+def test_i19_rotation_with_symmetry(detectorclass, pia_type, xia2_type, data_format):
     """Test the I19 rotation scenario with specified crystal symmetry."""
     dcid = 6356546
     other_dcid = 6356585
@@ -448,7 +448,7 @@ def test_i19_rotation_with_symmetry(detectorclass, pia_type, data_format):
                 "--new",
                 f"--dcid={dcid}",
                 "--source=automatic",
-                "--recipe=autoprocessing-multi-xia2-smallmolecule",
+                f"--recipe=autoprocessing-multi-xia2-smallmolecule{xia2_type}",
                 f"--add-sweep={dcid}:1:850",
                 f"--add-sweep={other_dcid}:1:850",
                 "--add-param=spacegroup:P1211",
@@ -463,7 +463,7 @@ def test_i19_rotation_with_symmetry(detectorclass, pia_type, data_format):
                 "--new",
                 f"--dcid={dcid}",
                 "--source=automatic",
-                "--recipe=autoprocessing-multi-xia2-smallmolecule",
+                f"--recipe=autoprocessing-multi-xia2-smallmolecule{xia2_type}",
                 f"--add-sweep={dcid}:1:850",
                 f"--add-sweep={other_dcid}:1:850",
                 "--add-param=absorption_level:medium",
@@ -476,7 +476,7 @@ def test_i19_rotation_with_symmetry(detectorclass, pia_type, data_format):
                 "--new",
                 f"--dcid={dcid}",
                 "--source=automatic",
-                "--recipe=autoprocessing-multi-xia2-smallmolecule-dials-aiml",
+                f"--recipe=autoprocessing-multi-xia2-smallmolecule-dials-aiml{xia2_type}",
                 f"--add-sweep={dcid}:1:850",
                 f"--add-sweep={other_dcid}:1:850",
                 "--add-param=spacegroup:P1211",
@@ -490,7 +490,7 @@ def test_i19_rotation_with_symmetry(detectorclass, pia_type, data_format):
                 "--new",
                 f"--dcid={dcid}",
                 "--source=automatic",
-                "--recipe=autoprocessing-multi-xia2-smallmolecule-dials-aiml",
+                f"--recipe=autoprocessing-multi-xia2-smallmolecule-dials-aiml{xia2_type}",
                 f"--add-sweep={dcid}:1:850",
                 f"--add-sweep={other_dcid}:1:850",
                 "--trigger",


### PR DESCRIPTION
For I19 Eiger data, use the `per-image-analysis-swmr` and `archive-nexus` recipes, instead of the `per-image-analysis` and `archive-cbfs` recipes used for Pilatus data.