### PR TITLE
Propagate new recipe name

### DIFF
--- a/src/dlstbx/mimas/core.py
+++ b/src/dlstbx/mimas/core.py
@@ -160,7 +160,7 @@ def run(
                         recipe="autoprocessing-multi-xia2-smallmolecule-dials-aiml"
                         if scenario.detectorclass
                         is dlstbx.mimas.MimasDetectorClass.PILATUS
-                        else "autoprocessing-multi-xia2-smallmolecule-dials-aiml-nexus",
+                        else "autoprocessing-multi-xia2-smallmolecule-d-a-nexus",
                         source="automatic",
                         sweeps=tuple(scenario.getsweepslistfromsamedcg),
                         parameters=symmetry_parameters,
@@ -185,7 +185,7 @@ def run(
                     autostart=True,
                     recipe="autoprocessing-multi-xia2-smallmolecule-dials-aiml"
                     if scenario.detectorclass is dlstbx.mimas.MimasDetectorClass.PILATUS
-                    else "autoprocessing-multi-xia2-smallmolecule-dials-aiml-nexus",
+                    else "autoprocessing-multi-xia2-smallmolecule-d-a-nexus",
                     source="automatic",
                     sweeps=tuple(scenario.getsweepslistfromsamedcg),
                 )

--- a/src/dlstbx/test/mimas/test_core.py
+++ b/src/dlstbx/test/mimas/test_core.py
@@ -344,14 +344,14 @@ def test_vmxi_rotation(anomalous_scatterer, absorption_level):
 
 
 @pytest.mark.parametrize(
-    "detectorclass, pia_type, xia2_type, data_format",
+    "detectorclass, pia_type, aimless_string, xia2_type, data_format",
     [
-        (MimasDetectorClass.PILATUS, "", "", "cbfs"),
-        (MimasDetectorClass.EIGER, "-swmr", "-nexus", "nexus"),
+        (MimasDetectorClass.PILATUS, "", "dials-aiml", "", "cbfs"),
+        (MimasDetectorClass.EIGER, "-swmr", "d-a", "-nexus", "nexus"),
     ],
     ids=("Pilatus", "Eiger"),
 )
-def test_i19_rotation(detectorclass, pia_type, xia2_type, data_format):
+def test_i19_rotation(detectorclass, pia_type, aimless_string, xia2_type, data_format):
     """Test the I19 rotation scenario."""
     dcid = 6356546
     other_dcid = 6356585
@@ -393,7 +393,7 @@ def test_i19_rotation(detectorclass, pia_type, xia2_type, data_format):
                 "--new",
                 f"--dcid={dcid}",
                 "--source=automatic",
-                f"--recipe=autoprocessing-multi-xia2-smallmolecule-dials-aiml{xia2_type}",
+                f"--recipe=autoprocessing-multi-xia2-smallmolecule-{aimless_string}{xia2_type}",
                 f"--add-sweep={dcid}:1:850",
                 f"--add-sweep={other_dcid}:1:850",
                 "--trigger",
@@ -407,14 +407,16 @@ def test_i19_rotation(detectorclass, pia_type, xia2_type, data_format):
 
 
 @pytest.mark.parametrize(
-    "detectorclass, pia_type, xia2_type, data_format",
+    "detectorclass, pia_type, aimless_string, xia2_type, data_format",
     [
-        (MimasDetectorClass.PILATUS, "", "", "cbfs"),
-        (MimasDetectorClass.EIGER, "-swmr", "-nexus", "nexus"),
+        (MimasDetectorClass.PILATUS, "", "dials-aiml", "", "cbfs"),
+        (MimasDetectorClass.EIGER, "-swmr", "d-a", "-nexus", "nexus"),
     ],
     ids=("Pilatus", "Eiger"),
 )
-def test_i19_rotation_with_symmetry(detectorclass, pia_type, xia2_type, data_format):
+def test_i19_rotation_with_symmetry(
+    detectorclass, pia_type, aimless_string, xia2_type, data_format
+):
     """Test the I19 rotation scenario with specified crystal symmetry."""
     dcid = 6356546
     other_dcid = 6356585
@@ -476,7 +478,7 @@ def test_i19_rotation_with_symmetry(detectorclass, pia_type, xia2_type, data_for
                 "--new",
                 f"--dcid={dcid}",
                 "--source=automatic",
-                f"--recipe=autoprocessing-multi-xia2-smallmolecule-dials-aiml{xia2_type}",
+                f"--recipe=autoprocessing-multi-xia2-smallmolecule-{aimless_string}{xia2_type}",
                 f"--add-sweep={dcid}:1:850",
                 f"--add-sweep={other_dcid}:1:850",
                 "--add-param=spacegroup:P1211",
@@ -490,7 +492,7 @@ def test_i19_rotation_with_symmetry(detectorclass, pia_type, xia2_type, data_for
                 "--new",
                 f"--dcid={dcid}",
                 "--source=automatic",
-                f"--recipe=autoprocessing-multi-xia2-smallmolecule-dials-aiml{xia2_type}",
+                f"--recipe=autoprocessing-multi-xia2-smallmolecule-{aimless_string}{xia2_type}",
                 f"--add-sweep={dcid}:1:850",
                 f"--add-sweep={other_dcid}:1:850",
                 "--trigger",


### PR DESCRIPTION
New name respects the ISPyB recipe schama 50-character limit on recipe names.  See [the corresponding change in the DLS Zocalo config](https://gitlab.diamond.ac.uk/scisoft/zocalo/-/merge_requests/30).