### PR TITLE
Adapt to I19-specific GDA behaviour for Eiger data

### DIFF
--- a/src/dlstbx/mimas/core.py
+++ b/src/dlstbx/mimas/core.py
@@ -95,7 +95,7 @@ def run(
         if scenario.beamline in ("i19-1", "i19-2"):
             # i19 is a special case
             if scenario.detectorclass is dlstbx.mimas.MimasDetectorClass.PILATUS:
-                for recipe in "archive-cbfs", "processing-rlv":
+                for recipe in "archive-cbfs", "processing-rlv", "strategy-screen19":
                     tasks.append(
                         dlstbx.mimas.MimasRecipeInvocation(
                             DCID=scenario.DCID, recipe=recipe
@@ -106,6 +106,7 @@ def run(
                     "archive-nexus",
                     "processing-rlv-eiger",
                     "generate-diffraction-preview",
+                    "strategy-screen19-eiger",
                 ):
                     tasks.append(
                         dlstbx.mimas.MimasRecipeInvocation(
@@ -113,12 +114,11 @@ def run(
                         )
                     )
 
-            for recipe in "strategy-screen19", "generate-crystal-thumbnails":
-                tasks.append(
-                    dlstbx.mimas.MimasRecipeInvocation(
-                        DCID=scenario.DCID, recipe=recipe
-                    )
+            tasks.append(
+                dlstbx.mimas.MimasRecipeInvocation(
+                    DCID=scenario.DCID, recipe="generate-crystal-thumbnails"
                 )
+            )
 
             if scenario.spacegroup:
                 # Space group is set, run xia2 with space group

--- a/src/dlstbx/test/mimas/test_core.py
+++ b/src/dlstbx/test/mimas/test_core.py
@@ -404,7 +404,7 @@ def test_i19_rotation(
         f"zocalo.go -r archive-{data_format} {dcid}",
         f"zocalo.go -r generate-crystal-thumbnails {dcid}",
         f"zocalo.go -r processing-rlv{rlv_type} {dcid}",
-        f"zocalo.go -r strategy-screen19 {dcid}",
+        f"zocalo.go -r strategy-screen19{rlv_type} {dcid}",
     }.union(
         {f"zocalo.go -r generate-diffraction-preview {dcid}"}
         if detectorclass is MimasDetectorClass.EIGER
@@ -507,7 +507,7 @@ def test_i19_rotation_with_symmetry(
         f"zocalo.go -r archive-{data_format} {dcid}",
         f"zocalo.go -r generate-crystal-thumbnails {dcid}",
         f"zocalo.go -r processing-rlv{rlv_type} {dcid}",
-        f"zocalo.go -r strategy-screen19 {dcid}",
+        f"zocalo.go -r strategy-screen19{rlv_type} {dcid}",
     }.union(
         {f"zocalo.go -r generate-diffraction-preview {dcid}"}
         if detectorclass is MimasDetectorClass.EIGER


### PR DESCRIPTION
- Generate a diffraction preview JPEG for Eiger data on I19.
  For Pilatus CBFs, this task is performed as part of the `per-image-analysis-rotation` recipe.  For Eigers, we need to run it separately.  This makes the frankentests for Mimas on I19 even uglier.
- Accommodate the I19-specific Eiger PIA recipe.
  This accommodates the idiosyncrasy on I19 that GDA registers the image prefix as something like `cytidine_01_`, rather than `cytidine`.  So rather than reconstruct the NeXus file name from the ISPyB fields `imagePrefix` and `dataCollectionNumber`, we need to take a truncated `imagePrefix`, to strip the trailing underscore.
  This also performs the PIA on every 100th image, rather than every 250th, to account for lower spot counts and smaller images than in most MX data collections.
- Accommodate the Eiger-specific screen19 recipe.
  This accommodates the fact that screen19 doesn't yet accept an Eiger data set with the suffix `:<first_image>:<last_image>`.

Depends on [scisoft/zocalo#31](https://gitlab.diamond.ac.uk/scisoft/zocalo/-/merge_requests/31).