### PR TITLE
Checks on particle picking and particle classification results for EM simulated data collections

### DIFF
--- a/src/dlstbx/dc_sim/definitions.py
+++ b/src/dlstbx/dc_sim/definitions.py
@@ -316,6 +316,12 @@ tests = {
                 }
                 for image_number in (set(range(21, 50)) - {32, 33, 34, 38, 41})
             },
+            "particle_picker": {
+                f"MotionCorr/job002/Movies/Frames/20170629_000{image_number}_frameImage.mrc": {
+                    "numberOfParticles": approx(250, 0.5),
+                }
+                for image_number in (set(range(21, 50)) - {32, 33, 34, 38, 41})
+            },
         },
     },
 }


### PR DESCRIPTION
Basic checks that there is a particle picking result for each micrograph and that a reasonable number of particles were picked. Also check that there are 50 particle classification rows in ISPyB (50 2D classes).