### PR TITLE
Make use of createdTimeStamp for movies when inserting motion correction records

### DIFF
--- a/src/dlstbx/services/ispybsvc_em.py
+++ b/src/dlstbx/services/ispybsvc_em.py
@@ -118,9 +118,10 @@ class EM_Mixin:
                 movie_params["dataCollectionId"] = full_parameters("dcid")
                 movie_params["movieNumber"] = full_parameters("image_number")
                 movie_params["movieFullPath"] = full_parameters("micrograph_full_path")
-                movie_params["createdTimeStamp"] = datetime.fromtimestamp(
-                    full_parameters("created_time_stamp")
-                ).strftime("%Y-%m-%d %H:%M:%S")
+                if full_parameters("created_time_stamp"):
+                    movie_params["createdTimeStamp"] = datetime.fromtimestamp(
+                        full_parameters("created_time_stamp")
+                    ).strftime("%Y-%m-%d %H:%M:%S")
                 movieid = self.ispyb.em_acquisition.insert_movie(
                     list(movie_params.values())
                 )


### PR DESCRIPTION
Together with DiamondLightSource/python-relion#130 this should resolve DiamondLightSource/python-relion#129