### PR TITLE
Fix `dlq_purge`

### DIFF
--- a/src/dlstbx/cli/dlq_purge.py
+++ b/src/dlstbx/cli/dlq_purge.py
@@ -115,11 +115,12 @@ def run() -> None:
         idlequeue.put_nowait("done")
 
     transport.connect()
-    if not queues and args.transport == "StompTransport":
-        queues = [dlqprefix + ".>"]
-    elif not queues and args.transport == "PikaTransport":
-        rmq = RabbitMQAPI.from_zocalo_configuration(zc)
-        queues = [q.name for q in rmq.queues() if q.name.startswith("dlq.")]
+    if not queues:
+        if args.transport == "StompTransport":
+            queues = [f"{dlqprefix}.>"]
+        elif args.transport == "PikaTransport":
+            rmq = RabbitMQAPI.from_zocalo_configuration(zc)
+            queues = [q.name for q in rmq.queues() if q.name.startswith("dlq.")]
     for queue_ in queues:
         print("Looking for DLQ messages in " + queue_)
         transport.subscribe(


### PR DESCRIPTION
Use RabbitMQ header format from `workflows>2.16` and use the HTTP API to get all dead letter queues if no queues are specified. Closes #121. These changes will also need to be propagated to the counterpart that lives in the `python-zocalo` repository. 