### PR TITLE
Use zocalo.util to get cluster/k8s information

### DIFF
--- a/requirements.conda.txt
+++ b/requirements.conda.txt
@@ -20,4 +20,4 @@ sqlalchemy>=1.4.0,<1.5
 stomp.py
 workflows>=2.15
 xmltodict
-zocalo>=0.11.1
+zocalo>=0.13.0

--- a/src/dlstbx/cli/service.py
+++ b/src/dlstbx/cli/service.py
@@ -4,7 +4,6 @@
 #
 
 import logging
-import os
 import sys
 import time
 
@@ -12,6 +11,7 @@ import workflows
 import workflows.contrib.start_service
 import workflows.logging
 import zocalo.configuration
+import zocalo.util
 
 import dlstbx.util
 from dlstbx.util.colorstreamhandler import ColorStreamHandler
@@ -123,16 +123,10 @@ class DLSTBXServiceStarter(workflows.contrib.start_service.ServiceStarter):
         if self.options.service_restart:
             frontend.restart_service = True
 
-        extended_status = {"zocalo": zocalo.__version__, "dlstbx": dlstbx_version()}
+        extended_status = zocalo.util.extended_status_dictionary()
+        extended_status["dlstbx"] = dlstbx_version()
         if self.options.tag:
             extended_status["tag"] = self.options.tag
-        for env in ("SGE_CELL", "JOB_ID"):
-            if env in os.environ:
-                extended_status["cluster_" + env] = os.environ[env]
-        if os.getenv("KUBERNETES") == "1":
-            split_name = os.environ["HOSTNAME"].split("-")
-            container_image = ":".join(split_name[:2])
-            extended_status["container_image"] = container_image
 
         original_status_function = frontend.get_status
 

--- a/src/dlstbx/cli/wrap.py
+++ b/src/dlstbx/cli/wrap.py
@@ -6,7 +6,6 @@
 
 import json
 import logging
-import os
 import sys
 from optparse import SUPPRESS_HELP, OptionParser
 
@@ -17,6 +16,7 @@ import workflows.services.common_service
 import workflows.transport
 import workflows.transport.offline_transport
 import workflows.util
+import zocalo.util
 import zocalo.wrapper
 from workflows.transport.stomp_transport import StompTransport
 
@@ -141,10 +141,9 @@ def run(cmdline_args=sys.argv[1:]):
         transport = workflows.transport.lookup(options.transport)()
     transport.connect()
     st = zocalo.wrapper.StatusNotifications(transport.broadcast_status, options.wrapper)
+    for field, value in zocalo.util.extended_status_dictionary().items():
+        st.set_static_status_field(field, value)
     st.set_static_status_field("dlstbx", dlstbx_version())
-    for env in ("SGE_CELL", "JOB_ID"):
-        if env in os.environ:
-            st.set_static_status_field("cluster_" + env, os.getenv(env))
 
     # Instantiate chosen wrapper
     instance = known_wrappers[options.wrapper]()()


### PR DESCRIPTION
Requires zocalo 0.13, which is already built and should become available on conda-forge within the next 15 minutes or so.