### PR TITLE
VMXm: mask copper rings in xia2-dials and PIA

### DIFF
--- a/src/dlstbx/mimas/core.py
+++ b/src/dlstbx/mimas/core.py
@@ -72,10 +72,11 @@ def handle_pilatus_not_gridscan_start(
 def handle_eiger_start(
     scenario: mimas.MimasScenario,
 ) -> List[mimas.Invocation]:
+    suffix = "-vmxm" if scenario.beamline == "i02-1" else ""
     recipe = (
-        "per-image-analysis-gridscan-swmr"
+        f"per-image-analysis-gridscan-swmr{suffix}"
         if scenario.dcclass is mimas.MimasDCClass.GRIDSCAN
-        else "per-image-analysis-rotation-swmr"
+        else f"per-image-analysis-rotation-swmr{suffix}"
     )
     return [mimas.MimasRecipeInvocation(DCID=scenario.DCID, recipe=recipe)]
 

--- a/src/dlstbx/test/mimas/test_core.py
+++ b/src/dlstbx/test/mimas/test_core.py
@@ -370,7 +370,7 @@ def test_vmxm_rotation():
         anomalous_scatterer=None,
     )
     assert get_zocalo_commands(scenario(event=MimasEvent.START)) == {
-        f"zocalo.go -r per-image-analysis-rotation-swmr {dcid}"
+        f"zocalo.go -r per-image-analysis-rotation-swmr-vmxm {dcid}"
     }
     assert get_zocalo_commands(scenario(event=MimasEvent.END)) == {
         f"ispyb.job --new --dcid={dcid} --source=automatic "
@@ -391,6 +391,28 @@ def test_vmxm_rotation():
         f"zocalo.go -r generate-crystal-thumbnails {dcid}",
         f"zocalo.go -r generate-diffraction-preview {dcid}",
         f"zocalo.go -r processing-rlv-eiger {dcid}",
+    }
+
+
+def test_vmxm_gridscan():
+    dcid = 7389147
+    scenario = functools.partial(
+        MimasScenario,
+        DCID=dcid,
+        dcclass=MimasDCClass.GRIDSCAN,
+        beamline="i02-1",
+        visit="nt27314-31",
+        runstatus="DataCollection Successful",
+        preferred_processing="xia2/DIALS",
+        detectorclass=MimasDetectorClass.EIGER,
+    )
+    assert get_zocalo_commands(scenario(event=MimasEvent.START)) == {
+        f"zocalo.go -r per-image-analysis-gridscan-swmr-vmxm {dcid}"
+    }
+    assert get_zocalo_commands(scenario(event=MimasEvent.END)) == {
+        f"zocalo.go -r archive-nexus {dcid}",
+        f"zocalo.go -r generate-crystal-thumbnails {dcid}",
+        f"zocalo.go -r generate-diffraction-preview {dcid}",
     }
 
 


### PR DESCRIPTION
Since all datasets on VMXm are collected on copper grids, mask out resolution rings corresponding to copper diffraction.

* Include extra copper ring mask parameters when running xia2-dials
* Also run xia2-dials with `remove_blanks=True` and `failover=True` (as for VMXi)
* VMXm-specific PIA recipes (the copper ring mask parameters are defined in the recipe)