### PR TITLE
Support for dynamically controlling cloud recipes

### DIFF
--- a/src/dlstbx/mimas/cloud.py
+++ b/src/dlstbx/mimas/cloud.py
@@ -2,61 +2,80 @@ from __future__ import annotations
 
 from typing import List
 
+import zocalo.configuration
+
 from dlstbx import mimas
-from dlstbx.mimas.core import is_end, is_rotation
+from dlstbx.mimas.core import (
+    is_end,
+    is_mx_beamline,
+    is_rotation,
+    is_vmxi,
+    xia2_dials_absorption_params,
+)
 from dlstbx.mimas.specification import BeamlineSpecification, VisitSpecification
 
-CLOUD_VISITS = {
-    "cm",
-    "lb",
-    "mx",
-    "nt31175",
-}
 
-
-is_cloud = (
-    VisitSpecification(CLOUD_VISITS)
-    & is_end
-    & is_rotation
-    & BeamlineSpecification("i04-1")
-)
-
-
-@mimas.match_specification(is_cloud)
+@mimas.match_specification(is_rotation & is_end & is_mx_beamline & ~is_vmxi)
 def handle_cloud(
     scenario: mimas.MimasScenario,
 ) -> List[mimas.Invocation]:
-    return [
-        # # xia2-dials
-        # mimas.MimasISPyBJobInvocation(
-        #     DCID=scenario.DCID,
-        #     autostart=True,
-        #     recipe="autoprocessing-xia2-dials-eiger-cloud",
-        #     source="automatic",
-        #     parameters=(
-        #         mimas.MimasISPyBParameter(
-        #             key="resolution.cc_half_significance_level", value="0.1"
-        #         ),
-        #         *xia2_dials_absorption_params(scenario),
-        #     ),
-        # ),
-        # xia2-3dii
-        mimas.MimasISPyBJobInvocation(
-            DCID=scenario.DCID,
-            autostart=True,
-            recipe="autoprocessing-xia2-3dii-eiger-cloud",
-            source="automatic",
-            parameters=(
-                mimas.MimasISPyBParameter(
-                    key="resolution.cc_half_significance_level", value="0.1"
-                ),
-            ),
-        ),
-        # autoPROC
-        mimas.MimasISPyBJobInvocation(
-            DCID=scenario.DCID,
-            autostart=True,
-            recipe="autoprocessing-autoPROC-eiger-cloud",
-            source="automatic",
-        ),
-    ]
+
+    tasks: List[mimas.Invocation] = []
+
+    zc = zocalo.configuration.from_file()
+    zc.activate()
+
+    if not zc.storage:
+        return tasks
+
+    visit_pattern = set(zc.storage.get("zocalo.mimas.cloud.visit_pattern", []))
+    cloud_beamlines = set(zc.storage.get("zocalo.mimas.cloud.beamlines", []))
+    cloud_recipes = set(zc.storage.get("zocalo.mimas.cloud.recipes", []))
+
+    cloud_spec = VisitSpecification(visit_pattern) & BeamlineSpecification(
+        beamlines=cloud_beamlines
+    )
+
+    if cloud_spec.is_satisfied_by(scenario):
+        if "autoprocessing-xia2-dials-eiger-cloud" in cloud_recipes:
+            tasks.append(
+                mimas.MimasISPyBJobInvocation(
+                    DCID=scenario.DCID,
+                    autostart=True,
+                    recipe="autoprocessing-xia2-dials-eiger-cloud",
+                    source="automatic",
+                    parameters=(
+                        mimas.MimasISPyBParameter(
+                            key="resolution.cc_half_significance_level", value="0.1"
+                        ),
+                        *xia2_dials_absorption_params(scenario),
+                    ),
+                )
+            )
+
+        if "autoprocessing-xia2-3dii-eiger-cloud" in cloud_recipes:
+            tasks.append(
+                mimas.MimasISPyBJobInvocation(
+                    DCID=scenario.DCID,
+                    autostart=True,
+                    recipe="autoprocessing-xia2-3dii-eiger-cloud",
+                    source="automatic",
+                    parameters=(
+                        mimas.MimasISPyBParameter(
+                            key="resolution.cc_half_significance_level", value="0.1"
+                        ),
+                    ),
+                )
+            )
+
+        if "autoprocessing-autoPROC-eiger-cloud" in cloud_recipes:
+            tasks.append(
+                mimas.MimasISPyBJobInvocation(
+                    DCID=scenario.DCID,
+                    autostart=True,
+                    recipe="autoprocessing-autoPROC-eiger-cloud",
+                    source="automatic",
+                )
+            )
+
+    return tasks


### PR DESCRIPTION
Read cloud configuration from `zocalo.configuration` storage plugin:

- Visit and beamline specifications can be controlled by `zocalo.mimas.cloud.visit_pattern` and `zocalo.mimas.cloud.beamlines` respectively.
- Individual recipes can be switched on/off via `zocalo.mimas.cloud.recipes`

This will read the zocalo configuration on every mimas call (well, calls that already match `is_rotation & is_end & is_mx_beamline & ~is_vmxi`). If this is not desirable, we could move the declaration of `cloud_spec` up to the module-level as before, however this would mean that we would need a service restart for any configuration changes to take effect (this would still be better than requiring a new dlstbx deployment as is currently the case). 

Example zocalo `configuration.yaml`:
```
diamond-zocalo-settings:
  plugin: storage
  zocalo.recipe_directory: /dls_sw/apps/zocalo/live/recipes
  zocalo.mimas.cloud.visit_pattern:
    - cm
    - lb
    - mx
    - nt31175
  zocalo.mimas.cloud.beamlines:
    - i04-1
    - i03
  zocalo.mimas.cloud.recipes:
    - autoprocessing-xia2-dials-eiger-cloud
    - autoprocessing-xia2-3dii-eiger-cloud
    - autoprocessing-autoPROC-eiger-cloud
```