### PR TITLE
Handle '#####.cbf' file template

### DIFF
--- a/src/dlstbx/wrapper/autoPROC.py
+++ b/src/dlstbx/wrapper/autoPROC.py
@@ -232,6 +232,7 @@ def construct_commandline(params, working_directory=None, image_directory=None):
 
 def get_untrusted_rectangles(first_image, macro=None):
     rectangles = []
+    first_image = str(first_image)
 
     if macro:
         # Parse any existing untrusted rectangles out of the macro
@@ -244,7 +245,10 @@ def get_untrusted_rectangles(first_image, macro=None):
                     rectangles.append(line.split("=")[-1].strip('"'))
 
     # Now add any untrusted rectangles defined in the dxtbx model
-    expts = ExperimentListFactory.from_filenames([str(first_image)])
+    if first_image.endswith(".cbf"):
+        expts = ExperimentListFactory.from_templates([first_image])
+    else:
+        expts = ExperimentListFactory.from_filenames([first_image])
     to_xds = xds.to_xds(expts[0].imageset)
     for panel, (x0, _, y0, _) in zip(to_xds.get_detector(), to_xds.panel_limits):
         for f0, s0, f1, s1 in panel.get_mask():


### PR DESCRIPTION
When using `dxtbx.model.experiment_list.ExperimentListFactory` to get untrusted rectangles, ensure that we use the `from_templates` method if the first_image is specified as a template with `#` placeholders for `[0-9]`, as will be the case for CBF input.

This ought to fix Graylog errors of [this type](https://graylog2.diamond.ac.uk/messages/zocalo_1546/adb4f591-94b2-11ec-9722-1866dafae8e4).