### PR TITLE
Require Python >=3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
 project_urls =
@@ -21,7 +20,7 @@ project_urls =
 
 [options]
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.8
 zip_safe = False
 
 [flake8]

--- a/src/dlstbx/__init__.py
+++ b/src/dlstbx/__init__.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import sys
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     import warnings
 
-    warnings.warn("dlstbx requires a Python 3.7+ environment", UserWarning)
+    warnings.warn("dlstbx requires a Python 3.8+ environment", UserWarning)
 
 
 def berkel_me():


### PR DESCRIPTION
[DiamondLightSource/python-zocalo](https://github.com/DiamondLightSource/python-zocalo) requires Python >=3.8, so DLSTBX already implicitly requires the same.