### PR TITLE
Fix htcondor deprecation warning

### DIFF
--- a/src/dlstbx/services/htcondorwatcher.py
+++ b/src/dlstbx/services/htcondorwatcher.py
@@ -95,7 +95,7 @@ class HTCondorWatcher(CommonService):
             with os_stat_profiler.record():
                 res = schedd.query(
                     constraint=f"ClusterId=={jobid}",
-                    attr_list=["ClusterId", "ProcId", "JobStatus", "Out"],
+                    projection=["ClusterId", "ProcId", "JobStatus", "Out"],
                 )
                 self.log.info(f"schedd status: {pformat(res)}")
                 if res:


### PR DESCRIPTION
As of htcondor 8.9.8 `attr_list` has been deprecated in favour of `projection`.

https://htcondor.readthedocs.io/en/latest/version-history/development-release-series-89.html#version-8-9-8
https://htcondor-wiki.cs.wisc.edu/index.cgi/tktview?tn=7630

Avoids the following warning:
```
/dials/conda_base/lib/python3.9/site-packages/htcondor/_deprecation.py:127: FutureWarning: The "attr_list" argument of query() will be renamed to "projection" in a future release. For now, it will accept both names.
```