### PR TITLE
More flexible mimas cloud specification

### DIFF
--- a/src/dlstbx/mimas/cloud.py
+++ b/src/dlstbx/mimas/cloud.py
@@ -27,73 +27,72 @@ def handle_cloud(
     if not zc.storage:
         return tasks
 
-    visit_pattern = set(zc.storage.get("zocalo.mimas.cloud.visit_pattern", []))
-    cloud_beamlines = set(zc.storage.get("zocalo.mimas.cloud.beamlines", []))
-    cloud_recipes = set(zc.storage.get("zocalo.mimas.cloud.recipes", []))
-
-    cloud_spec = VisitSpecification(visit_pattern) & BeamlineSpecification(
-        beamlines=cloud_beamlines
-    )
-
-    if cloud_spec.is_satisfied_by(scenario):
-        ParamTuple = Tuple[mimas.MimasISPyBParameter, ...]
-        extra_params: List[ParamTuple] = [()]
-        if scenario.spacegroup:
-            spacegroup = scenario.spacegroup.string
-            symmetry_parameters: ParamTuple = (
-                mimas.MimasISPyBParameter(key="spacegroup", value=spacegroup),
-            )
-            if scenario.unitcell:
-                symmetry_parameters += (
-                    mimas.MimasISPyBParameter(
-                        key="unit_cell", value=scenario.unitcell.string
-                    ),
+    for group in zc.storage.get("zocalo.mimas.cloud", []):
+        cloud_spec = VisitSpecification(
+            set(group.get("visit_pattern", []))
+        ) & BeamlineSpecification(beamlines=set(group.get("beamlines", [])))
+        cloud_recipes = set(group.get("recipes", []))
+        if cloud_spec.is_satisfied_by(scenario):
+            ParamTuple = Tuple[mimas.MimasISPyBParameter, ...]
+            extra_params: List[ParamTuple] = [()]
+            if scenario.spacegroup:
+                spacegroup = scenario.spacegroup.string
+                symmetry_parameters: ParamTuple = (
+                    mimas.MimasISPyBParameter(key="spacegroup", value=spacegroup),
                 )
-            extra_params.append(symmetry_parameters)
-
-        for params in extra_params:
-            if "autoprocessing-xia2-dials-eiger-cloud" in cloud_recipes:
-                tasks.append(
-                    mimas.MimasISPyBJobInvocation(
-                        DCID=scenario.DCID,
-                        autostart=True,
-                        recipe="autoprocessing-xia2-dials-eiger-cloud",
-                        source="automatic",
-                        parameters=(
-                            mimas.MimasISPyBParameter(
-                                key="resolution.cc_half_significance_level", value="0.1"
-                            ),
-                            *params,
-                            *xia2_dials_absorption_params(scenario),
+                if scenario.unitcell:
+                    symmetry_parameters += (
+                        mimas.MimasISPyBParameter(
+                            key="unit_cell", value=scenario.unitcell.string
                         ),
                     )
-                )
+                extra_params.append(symmetry_parameters)
 
-            if "autoprocessing-xia2-3dii-eiger-cloud" in cloud_recipes:
-                tasks.append(
-                    mimas.MimasISPyBJobInvocation(
-                        DCID=scenario.DCID,
-                        autostart=True,
-                        recipe="autoprocessing-xia2-3dii-eiger-cloud",
-                        source="automatic",
-                        parameters=(
-                            mimas.MimasISPyBParameter(
-                                key="resolution.cc_half_significance_level", value="0.1"
+            for params in extra_params:
+                if "autoprocessing-xia2-dials-eiger-cloud" in cloud_recipes:
+                    tasks.append(
+                        mimas.MimasISPyBJobInvocation(
+                            DCID=scenario.DCID,
+                            autostart=True,
+                            recipe="autoprocessing-xia2-dials-eiger-cloud",
+                            source="automatic",
+                            parameters=(
+                                mimas.MimasISPyBParameter(
+                                    key="resolution.cc_half_significance_level",
+                                    value="0.1",
+                                ),
+                                *params,
+                                *xia2_dials_absorption_params(scenario),
                             ),
-                            *params,
-                        ),
+                        )
                     )
-                )
 
-            if "autoprocessing-autoPROC-eiger-cloud" in cloud_recipes:
-                tasks.append(
-                    mimas.MimasISPyBJobInvocation(
-                        DCID=scenario.DCID,
-                        autostart=True,
-                        recipe="autoprocessing-autoPROC-eiger-cloud",
-                        source="automatic",
-                        parameters=params,
+                if "autoprocessing-xia2-3dii-eiger-cloud" in cloud_recipes:
+                    tasks.append(
+                        mimas.MimasISPyBJobInvocation(
+                            DCID=scenario.DCID,
+                            autostart=True,
+                            recipe="autoprocessing-xia2-3dii-eiger-cloud",
+                            source="automatic",
+                            parameters=(
+                                mimas.MimasISPyBParameter(
+                                    key="resolution.cc_half_significance_level",
+                                    value="0.1",
+                                ),
+                                *params,
+                            ),
+                        )
                     )
-                )
+
+                if "autoprocessing-autoPROC-eiger-cloud" in cloud_recipes:
+                    tasks.append(
+                        mimas.MimasISPyBJobInvocation(
+                            DCID=scenario.DCID,
+                            autostart=True,
+                            recipe="autoprocessing-autoPROC-eiger-cloud",
+                            source="automatic",
+                            parameters=params,
+                        )
+                    )
 
     return tasks


### PR DESCRIPTION
This allows `visit pattern` and `recipes` to be defined independently per individual or group of beamlines.

Example extended configuration:
```
  zocalo.mimas.cloud:
  - beamlines:
    - "i04-1"
    visit_pattern:
    - cm
    - lb
    - mx
    - nt31175
    recipes:
    - autoprocessing-xia2-3dii-eiger-cloud
  - beamlines:
    - "i03"
    - "i04"
    visit_pattern:
    - cm
    - nt31175
    recipes:
    - autoprocessing-xia2-3dii-eiger-cloud
    - autoprocessing-xia2-dials-eiger-cloud
```