### PR TITLE
PIA: optionally consume from alternative queue

### DIFF
--- a/src/dlstbx/cli/service.py
+++ b/src/dlstbx/cli/service.py
@@ -111,6 +111,13 @@ class DLSTBXServiceStarter(workflows.contrib.start_service.ServiceStarter):
             default=False,
             help="Restart service on failure",
         )
+        parser.add_option(
+            "-q",
+            "--queue",
+            dest="queue",
+            default=None,
+            help="Consume messages from this queue",
+        )
         self._zc.add_command_line_options(parser)
         self.log.debug("Launching %r", sys.argv)
 
@@ -131,6 +138,8 @@ class DLSTBXServiceStarter(workflows.contrib.start_service.ServiceStarter):
         kwargs["environment"] = kwargs.get("environment", {})
         kwargs["environment"]["live"] = self.use_live_infrastructure  # XXX deprecated
         kwargs["environment"]["config"] = self._zc
+        if self.options.queue:
+            kwargs["environment"]["queue"] = self.options.queue
         return kwargs
 
     def on_frontend_preparation(self, frontend):

--- a/src/dlstbx/services/per_image_analysis.py
+++ b/src/dlstbx/services/per_image_analysis.py
@@ -88,7 +88,7 @@ class DLSPerImageAnalysis(CommonService):
         # For every received message a single frame will be analysed.
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "per_image_analysis",
+            self._environment.get("queue") or "per_image_analysis",
             self.per_image_analysis,
             acknowledgement=True,
             log_extender=self.extend_log,


### PR DESCRIPTION
This allows us to e.g. run additional PIA services for ssx on a special queue set up with ttl=0 so that these services always consume the most recent message, with expired messages being sent to the standard PIA queue

See also https://gitlab.diamond.ac.uk/scisoft/zocalo/-/merge_requests/72