### PR TITLE
DCID search to DCID or DCGID

### DIFF
--- a/src/dlstbx/crud.py
+++ b/src/dlstbx/crud.py
@@ -21,10 +21,19 @@ def get_data_collection(
 
 def get_gridinfo_for_dcid(
     dcid: int,
+    dcgid: int,
     session: sqlalchemy.orm.session.Session,
 ) -> models.GridInfo | None:
     query = session.query(models.GridInfo).filter(
         models.GridInfo.dataCollectionId == dcid
+    )
+    result = query.first()
+    if result:
+        return result
+
+    # legacy: search on dcgid
+    query = session.query(models.GridInfo).filter(
+        models.GridInfo.dataCollectionGroupId == dcgid
     )
     return query.first()
 

--- a/src/dlstbx/ispybtbx/__init__.py
+++ b/src/dlstbx/ispybtbx/__init__.py
@@ -174,9 +174,11 @@ class ispybtbx:
 
         return message, parameters
 
-    def get_gridscan_info(self, dcid: int, session: sqlalchemy.orm.session.Session):
+    def get_gridscan_info(
+        self, dcid: int, dcgid: int, session: sqlalchemy.orm.session.Session
+    ):
         """Extract GridInfo table contents for a DC group ID."""
-        gridinfo = crud.get_gridinfo_for_dcid(dcid, session)
+        gridinfo = crud.get_gridinfo_for_dcid(dcid, dcgid, session)
         if not gridinfo:
             return {}
         schema = isa.GridInfo.__marshmallow__()
@@ -690,7 +692,7 @@ def ispyb_filter(
     parameters["ispyb_detectorclass"] = i.dc_info_to_detectorclass(dc_info, session)
     parameters["ispyb_dc_info"] = dc_info
     parameters["ispyb_dc_info"]["gridinfo"] = i.get_gridscan_info(
-        dc_info.get("dataCollectionId"), session
+        dc_info.get("dataCollectionId"), dc_info.get("dataCollectionGroupId"), session
     )
     parameters["ispyb_dcg_experiment_type"] = i.get_dcg_experiment_type(
         dc_info.get("dataCollectionGroupId"), session

--- a/src/dlstbx/test/test_crud.py
+++ b/src/dlstbx/test/test_crud.py
@@ -13,7 +13,7 @@ def test_get_data_collection(db_session):
 
 def test_get_gridinfo_for_dcid(db_session):
     dcid = 6017405
-    gi = crud.get_gridinfo_for_dcid(dcid, db_session)
+    gi = crud.get_gridinfo_for_dcid(dcid, 0, db_session)
     assert gi.dataCollectionId == dcid
 
 


### PR DESCRIPTION
in that order

Reverts behaviour similar to that before 257dc37a5d438f5cc1341532d0e821ec47fbf9f3 - allows recovery of gridinfo if only attached to data collection group