### PR TITLE
New service to dump PIA/indexing results to json-like file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ service_list = [
     "DLSValidation = dlstbx.services.validation:DLSValidation",
     "DLSXRayCentering = dlstbx.services.xray_centering:DLSXRayCentering",
     "HTCondorWatcher = dlstbx.services.htcondorwatcher:HTCondorWatcher",
-    "JSON = dlstbx.services.dump_json:JSON",
+    "JSONLines = dlstbx.services.jsonlines:JSONLines",
     # "LoadProducer = dlstbx.services.load_producer:LoadProducer",  # tentatively disabled
     # "LoadReceiver = dlstbx.services.load_receiver:LoadReceiver",  # tentatively disabled
 ]

--- a/src/dlstbx/services/jsonlines.py
+++ b/src/dlstbx/services/jsonlines.py
@@ -8,21 +8,21 @@ import workflows.recipe
 from workflows.services.common_service import CommonService
 
 
-class JSON(CommonService):
+class JSONLines(CommonService):
     """A service that takes RabbitMQ messages and moves them to ActiveMQ."""
 
     # Human readable service name
-    _service_name = "JSON"
+    _service_name = "JSON Lines"
 
     # Logger name
-    _logger_name = "dlstbx.services.json"
+    _logger_name = "dlstbx.services.jsonlines"
 
     def initializing(self):
 
         self._register_idle(1, self.process_messages)
         workflows.recipe.wrap_subscribe(
             self._transport,
-            "json",
+            "jsonlines",
             self.receive_msg,
             acknowledgement=True,
             exclusive=True,


### PR DESCRIPTION
Existing I24 SSX hitplotting scripts monitor a "[jsonlines](https://jsonlines.readthedocs.io/en/latest/)" style file that contains one JSON document per line, with the PIA results for each image.

This PR provides a new service that can consume PIA (and now indexing) output and dump the results into a file compatible with I24 SSX hitplotting scripts. Results are batched into groups of up to 100 in order to reduce the number of filesystem operations.