### PR TITLE
Add lower possible max value

### DIFF
--- a/src/dlstbx/services/validation.py
+++ b/src/dlstbx/services/validation.py
@@ -140,7 +140,7 @@ class DLSValidation(CommonService):
                             return fail("Missing VDS /entry/data/data")
                         data = fh["/entry/data/data"][0]
                         max_value = np.max(data)
-                        if max_value not in (0xFFFF, 0x7FFFFFFF, 0xFFFFFFFF):
+                        if max_value not in (0xFF, 0xFFFF, 0x7FFFFFFF, 0xFFFFFFFF):
                             return fail(
                                 f"Unxpected max pixel value found in {filename}: {max_value}"
                             )


### PR DESCRIPTION
Since a recent eiger firmware update, we have noted a dataset collected without beam had a count cutoff of 254 and a HIGH pixel value of 255, so I am proposing to add this to the list of accepted max pixel values