### PR TITLE
Validate dtype and bit_depth_readout

### DIFF
--- a/src/dlstbx/services/validation.py
+++ b/src/dlstbx/services/validation.py
@@ -158,7 +158,10 @@ class DLSValidation(CommonService):
                         return fail(
                             "All pixels are masked (is the detector set to full header mode?)"
                         )
-                    if data.dtype.itemsize > 4:
+                    if not (
+                        np.issubdtype(data.dtype, np.integer)
+                        and data.dtype.itemsize in {2, 4}
+                    ):
                         return fail(
                             f"Unexpected dtype={data.dtype} for {filename}{data.name} (expected 16-bit or 32-bit int)"
                         )


### PR DESCRIPTION
* Check that `dtype.itemsize <= 4`, i.e. data should not be stored at 64-bit int
* Check that `bit_depth_readout` is either 16 or 32
* Walk the VDS to validate that the dtype of the underlying real datasets is consistent with `bit_depth_readout`
* Run checks on all beamlines (i02-2 now appear to write a VDS)