### PR TITLE
Add ispyb_preferred_scheduler to dispatcher

### DIFF
--- a/src/dlstbx/ispybtbx/__init__.py
+++ b/src/dlstbx/ispybtbx/__init__.py
@@ -798,9 +798,11 @@ def ispyb_filter(
     dc_info["uuid"] = parameters.get("guid") or str(uuid.uuid4())
     parameters["ispyb_beamline"] = i.get_beamline_from_dcid(dc_id, session)
     if str(parameters["ispyb_beamline"]).lower() in _gpfs03_beamlines:
-        parameters["ispyb_preferred_datacentre"] = "hamilton"
+        parameters["ispyb_preferred_datacentre"] = "cs05r"
+        parameters["ispyb_preferred_scheduler"] = "slurm"
     else:
         parameters["ispyb_preferred_datacentre"] = "cluster"
+        parameters["ispyb_preferred_scheduler"] = "grid_engine"
     parameters["ispyb_detectorclass"] = i.dc_info_to_detectorclass(dc_info, session)
     parameters["ispyb_dc_info"] = dc_info
     parameters["ispyb_dc_info"]["gridinfo"] = i.get_gridscan_info(


### PR DESCRIPTION
** Not to be merged until shutdown **

This would enable a recipe to be used with both schedulers, depending on beamline:
```
{
    "1": { "service": "DLS cluster submission",
           "queue": "cluster.submission",
           "parameters": {
              "cluster": {
                "scheduler": "{ispyb_preferred_scheduler}",
                "cluster": "{ispyb_preferred_datacentre}",
                "partition": "{ispyb_preferred_datacentre}",
                "job_name": "dummy",
                "cpus_per_task": 2,
                "time_limit": "25:01:02",
                "account": "dls",
                "queue": "high",
                "commands": [
  "module load dials",
  "echo dlstbx.wrap -e offline --wrap dummy --recipewrapper \"$RECIPEWRAP\" >runinfo",
  "dlstbx.wrap -e offline --wrap dummy --recipewrapper \"$RECIPEWRAP\""
                           ]
              },
              "recipewrapper": "/dls/tmp/zocalo/test-slurm/dummy/.recipewrap",
              "workingdir": "/dls/tmp/zocalo/test-slurm/dummy/.launch"
            },
           "wrapper": { "task_information": "this is a test" }
         },
    "start": [
       [1, []]
    ]
  }
```