### PR TITLE
Only load the models for images being analysed

### DIFF
--- a/tests/services/test_per_image_analysis.py
+++ b/tests/services/test_per_image_analysis.py
@@ -32,7 +32,7 @@ def generate_recipe_message(parameters, output=None):
     return message
 
 
-def test_per_image_analysis(dials_data, mocker):
+def test_per_image_analysis_cbf(dials_data, mocker):
     image = dials_data("x4wide") / "X4_wide_M1S4_2_0001.cbf"
     mock_transport = mock.Mock()
     pia = DLSPerImageAnalysis()
@@ -71,9 +71,55 @@ def test_per_image_analysis(dials_data, mocker):
                     "total_intensity",
                 )
             },
-            "file": image,
+            "file": image.strpath,
             "file-number": 1,
             "file-pattern-index": 7,
+        },
+        transaction=mock.ANY,
+    )
+
+
+def test_per_image_analysis_h5(dials_data, mocker):
+    image = dials_data("vmxi_thaumatin") / "image_15799_master.h5"
+    mock_transport = mock.Mock()
+    pia = DLSPerImageAnalysis()
+    setattr(pia, "_transport", mock_transport)
+    pia.initializing()
+    t = mock.create_autospec(workflows.transport.common_transport.CommonTransport)
+    m = generate_recipe_message(
+        parameters={
+            "d_min": 4,
+            "scan_range": "3,3",
+        },
+        output={"any": 1, "select-2": 2},
+    )
+    payload = {
+        "file": image.strpath,
+        "file-number": 3,
+    }
+    rw = RecipeWrapper(message=m, transport=t)
+    # Spy on the rw.send_to method
+    send_to = mocker.spy(rw, "send_to")
+    pia.per_image_analysis(rw, {"subscription": mock.sentinel}, payload)
+    send_to.assert_called_with(
+        "result",
+        {
+            **{
+                k: mock.ANY
+                for k in (
+                    "d_min_distl_method_1",
+                    "d_min_distl_method_2",
+                    "estimated_d_min",
+                    "n_spots_4A",
+                    "n_spots_no_ice",
+                    "n_spots_total",
+                    "noisiness_method_1",
+                    "noisiness_method_2",
+                    "total_intensity",
+                )
+            },
+            "file": image.strpath,
+            "file-number": 3,
         },
         transaction=mock.ANY,
     )


### PR DESCRIPTION
For nexus files setting `load_models=True` (i.e. the default) when calling `ExperimentListFactory.from_filenames()` constructs an experiment object for every experiment in the data set. For an ssx dose series this could mean constructing over 250k experiments in order to do spotfinding on a single image, resulting in an approximately 5-fold increase in the time taken to do spotfinding. This change sets  for nexus files and then explicitly calls `expt.load_models()` for only the images being analysed.