### PR TITLE
Check validity of the slurm user token payload

### DIFF
--- a/requirements.conda.txt
+++ b/requirements.conda.txt
@@ -15,6 +15,7 @@ pydantic
 pytest
 pytest-mock
 python-htcondor>=9.2.0
+python-jose
 python-relion
 pyyaml
 pyzmq


### PR DESCRIPTION
If ExpiredSignatureError or any other JWTError is encountered then log exception and cause message to be nack'd

Depends on python-zocalo#231