### PR TITLE
Fix case when micronsPerPixelXY is null

### DIFF
--- a/src/dlstbx/services/xray_centering.py
+++ b/src/dlstbx/services/xray_centering.py
@@ -45,9 +45,11 @@ class GridInfo(pydantic.BaseModel):
         # into the database.
         # See also https://jira.diamond.ac.uk/browse/LIMS-464
         for axis in "XY":
-            values.setdefault(
-                f"micronsPerPixel{axis}", values.get(f"pixelsPerMicron{axis}")
-            )
+            if not values.get(f"micronsPerPixel{axis}"):
+                values[f"micronsPerPixel{axis}"] = values.get(f"pixelsPerMicron{axis}")
+            assert values[
+                f"micronsPerPixel{axis}"
+            ], f"micronsPerPixel{axis} value is {values[f'micronsPerPixel{axis}']}"
         return values
 
 

--- a/tests/services/test_xray_centering.py
+++ b/tests/services/test_xray_centering.py
@@ -15,6 +15,8 @@ def test_grid_info_params_from_legacy_pixels_per_micron():
         "orientation": "horizontal",
         "snapshot_offsetYPixel": 57.0822,
         "gridInfoId": 1337162,
+        "micronsPerPixelX": None,
+        "micronsPerPixelY": None,
         "dx_mm": 0.04,
         "steps_y": 5.0,
         "pixelsPerMicronX": 0.438,


### PR DESCRIPTION
Contingency code to handle transition from pixelsPerMicron -> micronsPerPixel when micronsPerPixelXY values are returned as NULL.