### PR TITLE
catch pydantic validation errors

### DIFF
--- a/src/dlstbx/services/cluster.py
+++ b/src/dlstbx/services/cluster.py
@@ -424,7 +424,7 @@ class DLSCluster(CommonService):
                 self.log.error(
                     "Error creating JobSubmissionParameters: %s", str(e), exc_info=True
                 )
-                self._transport.nack(header)
+                self._transport.nack(header, requeue=False)
                 return
 
         elif isinstance(legacy_cluster_submission_parameters, dict):
@@ -467,13 +467,13 @@ class DLSCluster(CommonService):
                 self.log.error(
                     "Error creating JobSubmissionParameters: %s", str(e), exc_info=True
                 )
-                self._transport.nack(header)
+                self._transport.nack(header, requeue=False)
                 return
         else:
             cluster_parameters = parameters.get("cluster", {})
             if not isinstance(cluster_parameters, Mapping):
                 self.log.error("Cannot extract parameters from field: cluster")
-                self._transport.nack(header)
+                self._transport.nack(header, requeue=False)
                 return
             try:
                 params = JobSubmissionParameters(**cluster_parameters)
@@ -481,7 +481,7 @@ class DLSCluster(CommonService):
                 self.log.error(
                     "Error creating JobSubmissionParameters: %s", str(e), exc_info=True
                 )
-                self._transport.nack(header)
+                self._transport.nack(header, requeue=False)
                 return
 
         if not isinstance(params.commands, str):


### PR DESCRIPTION
Chose to wrap each of the three JobSubmissionParameters separately. I imagine the message could be directly dlq'd rather than simply nack'd, but I'm not sure how to do this. 

I didn't manage to get this fully tested before the onset of pootageddon, will confirm it works at the next convenient time. 
