### PR TITLE
Slurm submission: don't copy submission host's env

### DIFF
--- a/src/dlstbx/services/cluster.py
+++ b/src/dlstbx/services/cluster.py
@@ -229,9 +229,7 @@ def submit_to_slurm(
             nodes=[params.nodes, params.nodes] if params.nodes else params.nodes,
             gpus_per_node=params.gpus_per_node,
             memory_per_node=params.memory_per_node,
-            environment=os.environ
-            if params.environment is None
-            else params.environment,
+            environment=params.environment or {},
             memory_per_cpu=params.min_memory_per_cpu,
             time_limit=time_limit_minutes,
             gpus=params.gpus,


### PR DESCRIPTION
When there is no `environment` specified in the job submission parameters, do not default to copying the entirety of the submission host's environment.  Instead, submit an empty dictionary (`environment` is not an optional field in [Zocalo's Slurm `JobProperties`](https://github.com/DiamondLightSource/python-zocalo/blob/1cfa23bfb7aee57c84d78c42930d4ddc0124f53a/src/zocalo/util/slurm/models.py#L102-L104) Pydantic model).

The cluster submission service currently runs as a near-infinite array job on the Science cluster.  This is because submitting to the Science cluster from Argus is not possible due some validation of the submitter's IP address, as seen by the UGE scheduler, against what the submitter itself thinks its address is.  This is non-trivial to resolve, so it's not possible to migrate the cluster submission service to a Kubernetes job until after UGE is retired and the Science cluster migrated to Slurm.

An unfortunate side-effect of defaulting to copying `os.environ` into the Slurm API job submission is that this includes various unwanted Grid Engine environment variables from the Science cluster node where the cluster submission service is running.  Variables such as `SGE_*` are clearly not necessary for running with Slurm, and `NSLOTS=1` is particularly problematic, as [`NSLOTS` is used by DIALS (and xia2, etc.) to dynamically determine the number of available cores for multiprocessing](https://github.com/dials/dials/blob/fff0ac694f420710f4975df69abf83c6f6d3324b/src/dials/util/mp.py#L40), taking precedence over other measures such as `len(os.sched_getaffinity(0))`.  This results in any job running DIALS with `nproc=Auto`, submitted to Wilson from the cluster submission service (itself running on a Science cluster node), wastefully running only as a single process, even if it has been allocated more than one core.

It is not clear whether there was ever a specific reason to default to copying `os.environ` into each API call.  If there was, this PR will break that behaviour.