### PR TITLE
Add recipe and triggering parameter support to cloudbursting specs

### DIFF
--- a/src/dlstbx/mimas/__init__.py
+++ b/src/dlstbx/mimas/__init__.py
@@ -4,7 +4,7 @@ import dataclasses
 import enum
 import functools
 import numbers
-from typing import Callable, List, Optional, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union
 
 import gemmi
 import pkg_resources
@@ -75,7 +75,7 @@ class MimasScenario:
     preferred_processing: Optional[str] = None
     detectorclass: Optional[MimasDetectorClass] = None
     anomalous_scatterer: Optional[MimasISPyBAnomalousScatterer] = None
-    is_cloudbursting: Optional[bool] = False
+    cloudbursting: Optional[list[dict[str, Any]]] = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -123,10 +123,10 @@ def validate(mimasobject, expectedtype=None):
 def _(mimasobject: MimasScenario, expectedtype=None):
     if expectedtype and not isinstance(mimasobject, expectedtype):
         raise ValueError(f"{mimasobject!r} is not a {expectedtype}")
-    if type(mimasobject.DCID) != int:
+    if type(mimasobject.DCID) is not int:
         raise ValueError(f"{mimasobject!r} has non-integer DCID")
     if mimasobject.visit is not None:
-        if type(mimasobject.visit) != str:
+        if type(mimasobject.visit) is not str:
             raise ValueError(f"{mimasobject!r} has non-string visit")
     validate(mimasobject.dcclass, expectedtype=MimasDCClass)
     validate(mimasobject.event, expectedtype=MimasEvent)
@@ -170,9 +170,9 @@ def _(mimasobject: MimasDetectorClass, expectedtype=None):
 def _(mimasobject: MimasRecipeInvocation, expectedtype=None):
     if expectedtype and not isinstance(mimasobject, expectedtype):
         raise ValueError(f"{mimasobject!r} is not a {expectedtype}")
-    if type(mimasobject.DCID) != int:
+    if type(mimasobject.DCID) is not int:
         raise ValueError(f"{mimasobject!r} has non-integer DCID")
-    if type(mimasobject.recipe) != str:
+    if type(mimasobject.recipe) is not str:
         raise ValueError(f"{mimasobject!r} has non-string recipe")
     if not mimasobject.recipe:
         raise ValueError(f"{mimasobject!r} has empty recipe string")
@@ -182,7 +182,7 @@ def _(mimasobject: MimasRecipeInvocation, expectedtype=None):
 def _(mimasobject: MimasISPyBJobInvocation, expectedtype=None):
     if expectedtype and not isinstance(mimasobject, expectedtype):
         raise ValueError(f"{mimasobject!r} is not a {expectedtype}")
-    if type(mimasobject.DCID) != int:
+    if type(mimasobject.DCID) is not int:
         raise ValueError(f"{mimasobject!r} has non-integer DCID")
     if mimasobject.autostart not in (True, False):
         raise ValueError(f"{mimasobject!r} has invalid autostart property")
@@ -192,7 +192,7 @@ def _(mimasobject: MimasISPyBJobInvocation, expectedtype=None):
         )
     for parameter in mimasobject.parameters:
         validate(parameter, expectedtype=MimasISPyBParameter)
-    if type(mimasobject.recipe) != str:
+    if type(mimasobject.recipe) is not str:
         raise ValueError(f"{mimasobject!r} has non-string recipe")
     if not mimasobject.recipe:
         raise ValueError(f"{mimasobject!r} has empty recipe string")
@@ -208,11 +208,11 @@ def _(mimasobject: MimasISPyBJobInvocation, expectedtype=None):
 def _(mimasobject: MimasISPyBParameter, expectedtype=None):
     if expectedtype and not isinstance(mimasobject, expectedtype):
         raise ValueError(f"{mimasobject!r} is not a {expectedtype}")
-    if type(mimasobject.key) != str:
+    if type(mimasobject.key) is not str:
         raise ValueError(f"{mimasobject!r} has non-string key")
     if not mimasobject.key:
         raise ValueError(f"{mimasobject!r} has an empty key")
-    if type(mimasobject.value) != str:
+    if type(mimasobject.value) is not str:
         raise ValueError(
             f"{mimasobject!r} value must be a string, not {type(mimasobject.value)}"
         )
@@ -222,15 +222,15 @@ def _(mimasobject: MimasISPyBParameter, expectedtype=None):
 def _(mimasobject: MimasISPyBSweep, expectedtype=None):
     if expectedtype and not isinstance(mimasobject, expectedtype):
         raise ValueError(f"{mimasobject!r} is not a {expectedtype}")
-    if type(mimasobject.DCID) != int:
+    if type(mimasobject.DCID) is not int:
         raise ValueError(f"{mimasobject!r} has non-integer DCID")
     if mimasobject.DCID <= 0:
         raise ValueError(f"{mimasobject!r} has an invalid DCID")
-    if type(mimasobject.start) != int:
+    if type(mimasobject.start) is not int:
         raise ValueError(f"{mimasobject!r} has non-integer start image")
     if mimasobject.start < 0:
         raise ValueError(f"{mimasobject!r} has an invalid start image")
-    if type(mimasobject.end) != int:
+    if type(mimasobject.end) is not int:
         raise ValueError(f"{mimasobject!r} has non-integer end image")
     if mimasobject.end < mimasobject.start:
         raise ValueError(f"{mimasobject!r} has an invalid end image")


### PR DESCRIPTION
Add `recipe` and `max_jobs_waiting` field suport to individual cloudbursting condition entries to allow triggering conditions to be applied to the different set of recipes. Individual entries can be disabled by adding `cloudbursting: false` into the relevant section.

Example:
The first entry defines three recipes for cloudbursing on `i04` and `i04-1` beamlines that always get triggered because of `max_jobs_waiting.live: -1` threshold that's always fulfilled as job queue size cannot go negative. The second entry uses global threshold settings to run two recipes in cloudbursting on `i03` for `nt33918` visit, but it's disabled because of `cloudbursting: false` setting.
```
  zocalo.mimas.cloud:
  - beamlines:
    - i04
    - i04-1
    visit_pattern:
    - cm
    - lb
    - mx
    recipes:
    - autoprocessing-xia2-3dii
    - autoprocessing-xia2-dials
    - autoprocessing-autoPROC
    max_jobs_waiting:
      live: -1
      iris: 500
  - beamlines:
    - i03
    visit_pattern:
    - nt33918
    recipes:
    - autoprocessing-multi-xia2-3dii
    - autoprocessing-multi-xia2-dials
    cloudbursting: false
  cloudbursting: true
  max_jobs_waiting:
    live: 50
    iris: 500
  timeout: 300
  s3echo_quota: 100
```