### PR TITLE
Make I03 use an I03-specific recipe. Really.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,6 +164,7 @@ mimas_scenario_handlers = [
     "eiger_end = dlstbx.mimas.core:handle_eiger_end",
     "i03_eiger_start_gridscan = dlstbx.mimas.core:handle_eiger_start_i03_gridscan",
     "i03_eiger_end = dlstbx.mimas.core:handle_eiger_end_i03",
+    "i03_eiger_end_i03 = dlstbx.mimas.core:handle_eiger_end_i03_and_i03_only",
     "i15_end = dlstbx.mimas.i15:handle_i15_end",
     "i19_pilatus_start = dlstbx.mimas.i19:handle_i19_start_pilatus",
     "i19_pilatus_end = dlstbx.mimas.i19:handle_i19_end_pilatus",

--- a/src/dlstbx/mimas/core.py
+++ b/src/dlstbx/mimas/core.py
@@ -92,7 +92,22 @@ def handle_eiger_start_i03_gridscan(
     ]
 
 
-@mimas.match_specification(is_eiger & is_end & is_mx_beamline & ~is_vmxi & ~is_serial)
+@mimas.match_specification(is_eiger & is_end & is_mx_beamline & is_i03)
+def handle_eiger_end_i03_and_i03_only(
+    scenario: mimas.MimasScenario,
+    **kwargs,
+) -> List[mimas.Invocation]:
+    recipe = (
+        "per-image-analysis-gridscan-i03-no-really"
+        if scenario.dcclass is mimas.MimasDCClass.GRIDSCAN
+        else "per-image-analysis-rotation-swmr"
+    )
+    return [mimas.MimasRecipeInvocation(DCID=scenario.DCID, recipe=recipe)]
+
+
+@mimas.match_specification(
+    is_eiger & is_end & is_mx_beamline & ~is_vmxi & ~is_serial & ~is_i03
+)
 def handle_eiger_end_i03(
     scenario: mimas.MimasScenario,
     **kwargs,


### PR DESCRIPTION
Will fix naming in shutdown when we move everything to gpfs04.

Make I03 use it's own recipe so we can change it for I03 only.