### PR TITLE
Remove preferred scheduler and data centre params

### DIFF
--- a/src/dlstbx/ispybtbx/__init__.py
+++ b/src/dlstbx/ispybtbx/__init__.py
@@ -764,8 +764,6 @@ def ispyb_filter(
         raise ValueError(f"No database entry found for dcid={dc_id}: {dc_id}")
     dc_info["uuid"] = parameters.get("guid") or str(uuid.uuid4())
     parameters["ispyb_beamline"] = i.get_beamline_from_dcid(dc_id, session)
-    parameters["ispyb_preferred_datacentre"] = "cs05r"
-    parameters["ispyb_preferred_scheduler"] = "slurm"
 
     parameters["ispyb_detectorclass"] = i.dc_info_to_detectorclass(dc_info, session)
     parameters["ispyb_dc_info"] = dc_info


### PR DESCRIPTION
All beamlines now use slurm as a scheduler and the cluster parameter is no longer used so there is no need for a preferred scheduler or datacentre parameter. Recipes have been updated to no longer use these parameters (see merge request [#124](https://gitlab.diamond.ac.uk/scisoft/zocalo/-/merge_requests/124) in zocalo configuration).