### PR TITLE
Check also for meta file

### DIFF
--- a/src/dlstbx/util/hdf5.py
+++ b/src/dlstbx/util/hdf5.py
@@ -57,6 +57,7 @@ def find_all_references(startfile):
                         startfile,
                         exc_info=True,
                     )
+                    raise ValueError(f"image data linked multiple times in {startfile}")
             if not entry.startswith("data_"):
                 image_count[filename] += 0
                 continue


### PR DESCRIPTION
The original version of this just walked over looking for _images_ and started from `/entry/data` which means we missed other externally linked files. This now adds an additional walker which checks over every group for external links and adds those and and when it finds them. This slightly changes the logic but I think the fixed logic is valid. 

N.B. this only checks one layer deep - if you have external links that have external links then that is _not_ checked for. 