### PR TITLE
Pass recipe comments to shelxt trigger

### DIFF
--- a/src/dlstbx/services/trigger.py
+++ b/src/dlstbx/services/trigger.py
@@ -208,6 +208,7 @@ class ShelxtParameters(pydantic.BaseModel):
     prefix: Optional[str]
     automatic: Optional[bool] = False
     scaling_id: int = pydantic.Field(gt=0)
+    comment: Optional[str] = None
 
 
 class DLSTrigger(CommonService):
@@ -2076,6 +2077,7 @@ class DLSTrigger(CommonService):
         jp["display_name"] = "shelxt"
         jp["recipe"] = "postprocessing-shelxt"
         jp["automatic"] = parameters.automatic
+        jp["comments"] = parameters.comment
         jobid = self.ispyb.mx_processing.upsert_job(list(jp.values()))
         self.log.debug(f"Shelxt trigger: generated JobID {jobid}")
 


### PR DESCRIPTION
in #250 I neglected to add a comment to the processingJob, which means when you trigger the downstream twice the default downstream view in synchweb is not able to show you which comes from which upstream. 

In other cases (dimple etc) a comment from the recipe _is_ passed to the trigger service and this comment is added to the  ProcessingJob, and this comment ends up displayed in the default view. 

If you have a dedicated synchweb view this comment is superseded by the scaling_id (which is used to get the name of the upstream directly) but the default view does not have that magic.