### PR TITLE
Sanitize unrolling snaked grid scans

### DIFF
--- a/src/dlstbx/services/xray_centering.py
+++ b/src/dlstbx/services/xray_centering.py
@@ -246,8 +246,8 @@ class DLSXRayCentering(CommonService):
                     dlstbx.util.xray_centering.reshape_grid(
                         cd.data,
                         (cd.gridinfo.steps_x, cd.gridinfo.steps_y),
-                        cd.gridinfo.snaked,
-                        cd.gridinfo.orientation,
+                        snaked=cd.gridinfo.snaked,
+                        orientation=cd.gridinfo.orientation,
                     )
                 ]
                 for _dcid in dcg_dcids:
@@ -261,8 +261,8 @@ class DLSXRayCentering(CommonService):
                         dlstbx.util.xray_centering.reshape_grid(
                             _cd.data,
                             (_cd.gridinfo.steps_x, _cd.gridinfo.steps_y),
-                            _cd.gridinfo.snaked,
-                            _cd.gridinfo.orientation,
+                            snaked=_cd.gridinfo.snaked,
+                            orientation=_cd.gridinfo.orientation,
                         )
                     )
                 else:

--- a/src/dlstbx/util/xray_centering.py
+++ b/src/dlstbx/util/xray_centering.py
@@ -43,7 +43,7 @@ class GridScan2DResult(GridScanResultBase):
 
 
 def reshape_grid(
-    data: np.ndarray, steps: tuple[int, int], snaked: bool, orientation: Orientation
+    data: np.ndarray, steps: tuple[int, int], *, snaked: bool, orientation: Orientation
 ) -> np.ndarray:
     if orientation == Orientation.VERTICAL:
         data = data.reshape(steps)
@@ -84,7 +84,7 @@ def gridscan2d(
             message="No good images found",
         ), "\n".join(output)
 
-    data = reshape_grid(data, steps, snaked, orientation).T
+    data = reshape_grid(data, steps, snaked=snaked, orientation=orientation).T
 
     output.append(f"There are {maximum_spots} reflections in image #{best_image}.")
 


### PR DESCRIPTION
This is awful, it was not shuffling the data for the first grid scan. The code is pretty much obfuscated though, matplotlib plotting the results helped a lot.