### PR TITLE
Catch directory is visit root

### DIFF
--- a/src/dlstbx/ispybtbx/__init__.py
+++ b/src/dlstbx/ispybtbx/__init__.py
@@ -664,6 +664,8 @@ class ispybtbx:
             raise ValueError("Got relative directory instead of absolute")
         if len(directory.parts) < 6:
             return None
+        if len(directory.parts) == 6:
+            return str(directory)
         return str(directory.parents[-6])
 
     @staticmethod


### PR DESCRIPTION
Catch the corner case where files are collected into visit root, so return the directory