### PR TITLE
Add absolute threshold

### DIFF
--- a/contrib/feed_xrc.py
+++ b/contrib/feed_xrc.py
@@ -170,6 +170,8 @@ for i, dc in enumerate(dcs):
         "dcg_dcids": [x.dcid for x in dcs[:i]],
         "experiment_type": "Mesh3D",
         "beamline": "i03",
+        "threshold": 0.05,
+        "threshold_absolute": 5
     }
 
     rw = RecipeWrapper(

--- a/src/dlstbx/services/xray_centering.py
+++ b/src/dlstbx/services/xray_centering.py
@@ -65,7 +65,8 @@ class Parameters(pydantic.BaseModel):
     latency_log_warning: float = 30
     latency_log_error: float = 300
     beamline: str
-    threshold: pydantic.NonNegativeFloat = 0.25
+    threshold: pydantic.NonNegativeFloat = 0.05
+    threshold_absolute: pydantic.NonNegativeFloat = 5
 
 
 class RecipeStep(pydantic.BaseModel):
@@ -278,6 +279,7 @@ class DLSXRayCentering(CommonService):
                     result = dlstbx.util.xray_centering_3d.gridscan3d(
                         data=tuple(data),
                         threshold=parameters.threshold,
+                        threshold_absolute=parameters.threshold_absolute,
                         plot=False,
                     )
                     self.log.info(f"3D X-ray centering result: {result}")


### PR DESCRIPTION
Used for multi-sample pins, apply an absolute threshold to grid scans before composing the 3D grid scan. Default chosen to be low i.e. 5 spots minimum, and vastly lowered the relative threshold since we no longer need to consider the risk of nonsense from the background