### PR TITLE
Fix pydantic 2 update more

### DIFF
--- a/src/dlstbx/services/ssx_plotter.py
+++ b/src/dlstbx/services/ssx_plotter.py
@@ -47,10 +47,10 @@ class Payload(pydantic.BaseModel):
     every: int = 1
     spot_count_cutoff: pydantic.NonNegativeInt = 16
     files_expected: Optional[pydantic.NonNegativeInt] = pydantic.Field(
-        alias="files-expected"
+        default=None, alias="files-expected"
     )
     images_expected: Optional[pydantic.NonNegativeInt] = pydantic.Field(
-        alias="images-expected"
+        default=None, alias="images-expected"
     )
     timeout: pydantic.PositiveFloat = 3600
     status: Optional[Status] = None

--- a/src/dlstbx/services/trigger.py
+++ b/src/dlstbx/services/trigger.py
@@ -179,15 +179,15 @@ class BestParameters(pydantic.BaseModel):
 
 class RelatedDCIDs(pydantic.BaseModel):
     dcids: List[int]
-    sample_id: Optional[int] = pydantic.Field(gt=0)
-    sample_group_id: Optional[int] = pydantic.Field(gt=0)
+    sample_id: Optional[int] = pydantic.Field(default=None, gt=0)
+    sample_group_id: Optional[int] = pydantic.Field(default=None, gt=0)
 
 
 class MultiplexParameters(pydantic.BaseModel):
     dcid: int = pydantic.Field(gt=0)
     related_dcids: List[RelatedDCIDs]
     program_id: Optional[int] = pydantic.Field(default=0, gt=0)
-    wavelength: Optional[float] = pydantic.Field(gt=0)
+    wavelength: Optional[float] = pydantic.Field(default=None, gt=0)
     spacegroup: Optional[str] = None
     automatic: Optional[bool] = False
     comment: Optional[str] = None
@@ -203,7 +203,7 @@ class MultiplexParameters(pydantic.BaseModel):
 class Xia2SsxReduceParameters(pydantic.BaseModel):
     dcid: int = pydantic.Field(gt=0)
     related_dcids: List[RelatedDCIDs]
-    wavelength: Optional[float] = pydantic.Field(gt=0)
+    wavelength: Optional[float] = pydantic.Field(default=None, gt=0)
     spacegroup: Optional[str] = None
     automatic: Optional[bool] = False
     comment: Optional[str] = None


### PR DESCRIPTION
PR #247 updated dlstbx to pydantic 2. Some fixes were applied in #265. Despite this, it was found that the multiplex trigger was failing validation in production. The cause was found to be due to some optional fields missing a default value, causing pydantic to fail validation as without a default value, pydantic still expects the field to exist in the input message but will allow its value to be `None`. In this fix, the remaining pydantic fields that do not have specified default values have been given default values of `None` .