### PR TITLE
Set default thresholds to single-sample pin values

### DIFF
--- a/src/dlstbx/services/xray_centering.py
+++ b/src/dlstbx/services/xray_centering.py
@@ -70,7 +70,7 @@ class Parameters(pydantic.BaseModel):
     sample_id: Optional[int] = None
     loop_type: Optional[str] = None
     msp_sample_ids: Optional[dict[int, int]] = {}
-    threshold: pydantic.NonNegativeFloat = 0.5
+    threshold: pydantic.NonNegativeFloat = 0.25
     threshold_absolute: pydantic.NonNegativeFloat = 0
 
 

--- a/src/dlstbx/util/xray_centering_3d.py
+++ b/src/dlstbx/util/xray_centering_3d.py
@@ -46,7 +46,7 @@ class GridScan3DResult(GridScanResultBase):
 
 def gridscan3d(
     data: tuple[np.ndarray, ...],
-    threshold: float = 0.5,
+    threshold: float = 0.25,
     threshold_absolute: float = 0,
     plot: bool = False,
     sample_id: int | None = None,


### PR DESCRIPTION
Set the default behaviour of the Xray centring service to not use an absolute threshold and to use a relative threshold of 0.25, which was the previous default value prior to recent changes (#262). 

The defaults that they replace in this PR were set for multi-sample pins, which are not currently in general use.   

Resolves #281 