### PR TITLE
Regenerate dispatchers to fix image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN source /dials/dials \
 
 RUN source /dials/dials \
   && sed -i'' 's|libtbx.conda|/dials/conda_base/condabin/conda|' "/dials/modules/dlstbx/src/dlstbx/requirements.py" \
-  && libtbx.python /dials/modules/dlstbx/candygram/candygram.py zocalo dials dials_data dxtbx xia2 sphinx fast_dp screen19 dials_research dlstbx \
+  && libtbx.python /dials/modules/dlstbx/contrib/candygram.py  dials dials_data dials_research dlstbx dxtbx fast_dp screen19 sphinx xia2 zocalo \
   && python3 /dials/modules/dlstbx/src/dlstbx/requirements.py python-relion -y \
   && pip3 install git+https://github.com/DiamondLightSource/python-workflows@diag_emptyheader
 


### PR DESCRIPTION
Adds the `candygram.py` script from [the dials_jenkins_pipelines repository](https://gitlab.diamond.ac.uk/scisoft/mx/dials_jenkins_pipelines/-/blob/0f03b6347c5bf8aa91d248afaa25852b74c76e54/candygram.py) to uses it to regenrate the relevant dispatchers when building the image.

The `candygram.py` script requires `patchelf` as a dependency, so this is also added to the Dockerfile