### PR TITLE
Enable support to retriggering for downstream processing pipelines

### DIFF
--- a/src/dlstbx/wrapper/xia2_to_shelxcde.py
+++ b/src/dlstbx/wrapper/xia2_to_shelxcde.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import glob
 import os
-
-import procrunner
-import py
+import pathlib
+import re
+import shutil
+import subprocess
+import time
 
 import dlstbx.util.symlink
 from dlstbx.util.shelxc import parse_shelxc_logs
@@ -18,28 +20,28 @@ class Xia2toShelxcdeWrapper(Wrapper):
         assert hasattr(self, "recwrap"), "No recipewrapper object found"
         params = self.recwrap.recipe_step["job_parameters"]
 
-        working_directory = py.path.local(os.path.join(params["working_directory"]))
-        try:
-            results_directory = py.path.local(
-                os.path.realpath(os.path.join(params["results_directory"]))
-            )
-        except KeyError:
-            self.log.debug("Result directory not specified")
+        working_directory = pathlib.Path(params.get("working_directory", os.getcwd()))
+        working_directory.mkdir(parents=True, exist_ok=True)
 
         # Create working directory with symbolic link
-        working_directory.ensure(dir=True)
         if params.get("create_symlink"):
             try:
                 levels = params["levels_symlink"]
                 dlstbx.util.symlink.create_parent_symlink(
-                    working_directory.strpath, params["create_symlink"], levels=levels
+                    working_directory, params["create_symlink"], levels=levels
                 )
             except KeyError:
                 dlstbx.util.symlink.create_parent_symlink(
-                    working_directory.strpath, params["create_symlink"]
+                    working_directory, params["create_symlink"]
                 )
 
-        data_files = sorted(glob.glob(params["data"]))
+        data_files = sorted(
+            pth
+            for pth in glob.glob(
+                str(pathlib.Path(params["data"]).parent / "**"), recursive=True
+            )
+            if re.search(params["data"], pth)
+        )
         if not data_files:
             self.log.error(
                 "Could not find data files matching %s to process", params["data"]
@@ -57,43 +59,55 @@ class Xia2toShelxcdeWrapper(Wrapper):
         command = ["xia2.to_shelxcde"] + file_list + ["shelxc"]
         self.log.info("Generating SHELXC .ins file")
         self.log.info("command: %s", " ".join(command))
-        result = procrunner.run(
-            command,
-            timeout=params.get("timeout"),
-            working_directory=working_directory.strpath,
-        )
-        if result["exitcode"] or result["timeout"]:
-            self.log.info("timeout: %s", result["timeout"])
-            self.log.info("exitcode: %s", result["exitcode"])
-            self.log.debug(result["stdout"].decode("latin1"))
-            self.log.debug(result["stderr"].decode("latin1"))
-        self.log.info("runtime: %s", result["runtime"])
-
+        try:
+            start_time = time.perf_counter()
+            result = subprocess.run(
+                command,
+                cwd=working_directory,
+                text=True,
+                timeout=params.get("timeout"),
+            )
+            runtime = time.perf_counter() - start_time
+            self.log.info(f"runtime: {runtime: .1f} seconds")
+        except subprocess.TimeoutExpired as te:
+            self.log.info(f"timeout: {te.timeout}")
+            self.log.debug(te.stdout)
+            self.log.debug(te.stderr)
+        else:
+            if result.returncode:
+                self.log.info(f"exitcode: {result.returncode}")
+                self.log.debug(result.stdout)
+                self.log.debug(result.stderr)
         command = ["sh", "shelxc.sh"]
         self.log.info("Starting SHELXC")
         self.log.info("command: %s", " ".join(command))
-        result = procrunner.run(
-            command,
-            timeout=params.get("timeout"),
-            working_directory=working_directory.strpath,
-        )
-
-        if result["exitcode"] or result["timeout"]:
-            self.log.info("timeout: %s", result["timeout"])
-            self.log.info("exitcode: %s", result["exitcode"])
-            self.log.debug(result["stdout"].decode("latin1"))
-            self.log.debug(result["stderr"].decode("latin1"))
-        self.log.info("runtime: %s", result["runtime"])
-
-        if not result["stdout"]:
+        try:
+            start_time = time.perf_counter()
+            result = subprocess.run(
+                command,
+                cwd=working_directory,
+                capture_output=True,
+                text=True,
+                timeout=params.get("timeout"),
+            )
+            runtime = time.perf_counter() - start_time
+            self.log.info(f"runtime: {runtime: .1f} seconds")
+        except subprocess.TimeoutExpired as te:
+            self.log.info(f"timeout: {te.timeout}")
+            self.log.debug(te.stdout)
+            self.log.debug(te.stderr)
+        else:
+            if result.returncode:
+                self.log.info(f"exitcode: {result.returncode}")
+                self.log.debug(result.stdout)
+                self.log.debug(result.stderr)
+        if not result.stdout:
             self.log.debug("SHELXC log is empty")
             return False
 
-        shelxc_log = os.path.join(working_directory.strpath, "results_shelxc.log")
-        with open(shelxc_log, "w") as fp:
-            fp.write(result["stdout"].decode("latin1"))
-
-        stats = parse_shelxc_logs(result["stdout"].decode("latin1"), self.log)
+        with (working_directory / "results_shelxc.log").open("w") as fp:
+            fp.write(result.stdout)
+        stats = parse_shelxc_logs(result.stdout, self.log)
         if not stats:
             self.log.debug("Cannot process SHELXC data. Aborting.")
             return False
@@ -101,25 +115,29 @@ class Xia2toShelxcdeWrapper(Wrapper):
 
         # Create results directory and symlink if they don't already exist
         try:
-            self.log.info("Copying SHELXC results to %s", results_directory.strpath)
-            results_directory.ensure(dir=True)
+            results_directory = pathlib.Path(params["results_directory"])
+            results_directory.mkdir(parents=True, exist_ok=True)
+        except KeyError:
+            self.log.debug("Result directory not specified")
+        try:
+            self.log.info("Copying SHELXC results to %s", results_directory)
             if params.get("create_symlink"):
                 try:
                     levels = params["levels_symlink"]
                     dlstbx.util.symlink.create_parent_symlink(
-                        results_directory.strpath,
+                        results_directory,
                         params["create_symlink"],
                         levels=levels,
                     )
                 except KeyError:
                     dlstbx.util.symlink.create_parent_symlink(
-                        results_directory.strpath, params["create_symlink"]
+                        results_directory, params["create_symlink"]
                     )
-            for f in working_directory.listdir():
-                if f.ext in [".log", ".hkl", ".sh", ".ins", ".cif"]:
-                    f.copy(results_directory)
+            for f in working_directory.iterdir():
+                if f.suffix in [".log", ".hkl", ".sh", ".ins", ".cif"]:
+                    shutil.copy(f, results_directory)
         except NameError:
             self.log.debug(
                 "Ignore copying SHELXC results. Results directory not specified."
             )
-        return result["exitcode"] == 0
+        return result.returncode == 0


### PR DESCRIPTION
Implement changes to support triggering downstream pipeline re-processing using the `autoprocscaling_id` value, which refers to scaling results from an upstream data reduction pipeline. The trigger service has been extended to support dictionary entries for input data, as defined in reprocessing recipes. These entries include the pipeline name along with the corresponding input file pattern. The dictionary in the reprocessing recipes will contain a list of all supported upstream pipelines and their associated result file patterns. The trigger service will use the provided `scaling_id` value to identify the name of the upstream pipeline, retrieve the corresponding input file templates, read the matching input data files, and trigger the downstream processing accordingly.