### PR TITLE
Ignore dcs with missing wavelength in multiplex trigger

### DIFF
--- a/src/dlstbx/services/trigger.py
+++ b/src/dlstbx/services/trigger.py
@@ -1908,6 +1908,11 @@ class DLSTrigger(CommonService):
             data_files = []
             for dc, app, pj in query.all():
                 # Select only those dcids at the same wavelength as the triggering dcid
+                if not dc.wavelength:
+                    self.log.debug(
+                        f"Discarding appid {app.autoProcProgramId} (no wavelength information)"
+                    )
+                    continue
                 if (
                     parameters.wavelength
                     and abs(dc.wavelength - parameters.wavelength)


### PR DESCRIPTION
Discards data collections with missing wavelength information in multiplex trigger and prevents the trigger service from crashing in such an instance. 