### PR TITLE
Add trigger for Metal ID on I23

### DIFF
--- a/src/dlstbx/services/trigger.py
+++ b/src/dlstbx/services/trigger.py
@@ -656,7 +656,7 @@ class DLSTrigger(CommonService):
             "autoPROC+STARANISO": "staraniso_alldata-unique.mtz",
         }
 
-        if proc_prog not in input_file_patterns.keys():
+        if proc_prog not in input_file_patterns:
             self.log.info(
                 f"Skipping metal id trigger: {proc_prog} is not an accepted upstream processing pipeline for metal id"
             )

--- a/src/dlstbx/util/metal_id_helpers.py
+++ b/src/dlstbx/util/metal_id_helpers.py
@@ -62,11 +62,11 @@ def dcids_from_related_dcids(
         )
         return []
 
-    if match := re.search(r"E(\d+)$", str(dc_info.imagePrefix)):
+    if match := re.search(r"_E(\d+)$", str(dc_info.imagePrefix)):
         energy_num = int(match.group(1))
     else:
         logger.info(
-            "Skipping metal id trigger: Image prefix does not end with E# where # is an integer"
+            "Skipping metal id trigger: Image prefix does not end with _E# where # is an integer"
         )
         return []
 
@@ -79,7 +79,7 @@ def dcids_from_related_dcids(
         .filter(DataCollection.dataCollectionId.in_(dcids))
         .filter(DataCollection.numberOfImages == dc_info.numberOfImages)
         .filter(DataCollection.startImageNumber == dc_info.startImageNumber)
-        .filter(DataCollection.imagePrefix.endswith(f"E{energy_num - 1}"))
+        .filter(DataCollection.imagePrefix.endswith(f"_E{energy_num - 1}"))
         .filter(DataCollection.SESSIONID == dc_info.SESSIONID)
     )
     if not len(query.all()):


### PR DESCRIPTION
I23 want the metal_id pipeline to be automated on data collections.The agreed method for establishing an experiment as a metal_id experiment on I23 is to use the GDA feature for MAD experiments, which sets up a series of data collections with the `_E#` at the end of the filename, where # is an integer. This PR adds logic to the metal_id trigger function to see if the file name matches this pattern and, if it does, to find related dcids, then run the pipeline.

The code is compatible with "interleaving" type experiments where the rotation experiment is split up into wedges and is recorded at alternating energies to spread the effect of beam damage over both collections. The idea being that xia2.multiplex would combine the data sets and then act as the ideal input for metal_id.

This PR requires changes to the metal_id recipe and for triggers to be added to autoprocessing recipes for non-eiger detectors to take effect. 