### PR TITLE
Add symmetry info to xoalign output

### DIFF
--- a/src/dlstbx/wrapper/xoalign.py
+++ b/src/dlstbx/wrapper/xoalign.py
@@ -131,7 +131,6 @@ class XOalignWrapper(Wrapper):
 
             if match := unit_cell_pattern.search(line):
                 unit_cell = [float(uc_param) for uc_param in match.groups()]
-                self.log.info(f"Found unit cell: {unit_cell}")
                 found_unit_cell = True
 
             if found_space_group and found_unit_cell:


### PR DESCRIPTION
The XOalign output in SynchWeb has been edited to include unit cell and space group information, to match the output of the dials.align_crystal pipelines. This PR retrieves the necessary information from the log file and creates a corresponding record in the ScreeningOutputLattice table. 