### PR TITLE
Fix filename substitution in big_ep trigger

### DIFF
--- a/src/dlstbx/services/trigger.py
+++ b/src/dlstbx/services/trigger.py
@@ -1625,10 +1625,13 @@ class DLSTrigger(CommonService):
                     pass
 
                 for input_file in ("data", "scaled_unmerged_mtz"):
-                    processing_params = parameter_map.get(app.processingPrograms, {})
+                    processing_params = ChainMapWithReplacement(
+                        parameter_map.get(app.processingPrograms, {}),
+                        substitutions=rw.environment,
+                    )
                     input_filename = getattr(
                         parameters, input_file
-                    ) or processing_params.get(input_file)
+                    ) or processing_params.get(input_file, "")
                     if pathlib.Path(input_filename).is_file():
                         big_ep_params[input_file] = pathlib.Path(input_filename)
                     else:
@@ -1636,12 +1639,7 @@ class DLSTrigger(CommonService):
                         app_file = pathlib.Path(app.filePath) / app.fileName
                         if re.search(str(input_filename), str(app_file)):
                             big_ep_params[input_file] = app_file
-            big_ep_params = BigEPParams(
-                **ChainMapWithReplacement(
-                    big_ep_params,
-                    substitutions=rw.environment,
-                )
-            )
+            big_ep_params = BigEPParams(**big_ep_params)
         else:
             self.log.error("big_ep trigger failed: No scaling_id value specified")
             return False


### PR DESCRIPTION
When multiplex triggers big_ep, it passes the filenames using placeholders with the corresponding values stored in the recipewrapper environment. Changes made to the big_ep trigger to enable downstream reprocessing broke this substitution as a check that the input_file path is a file is made against the placeholder string rather than the path itself.

Fix this by moving the ChainMapWithReplacement call earlier in the code so that the substitution has been made before the check. 