### PR TITLE
include .sca in multiplex output

### DIFF
--- a/src/dlstbx/wrapper/xia2_multiplex.py
+++ b/src/dlstbx/wrapper/xia2_multiplex.py
@@ -259,12 +259,14 @@ class Xia2MultiplexWrapper(Wrapper):
             ".refl": None,
             ".mtz": None,
             ".html": "log",
+            ".sca": None,
         }
         keep = {
             "scaled.mtz": "result",
             "scaled_unmerged.mtz": "result",
             "scaled.expt": "result",
             "scaled.refl": "result",
+            "scaled.sca": "result",
             "merging-stats.json": "graph",
             "xia2.multiplex.json": "result",
         }


### PR DESCRIPTION
Addresses [Ticket #52](https://github.com/DiamondLightSource/mx-analysis/issues/52) - I23 would like the .sca file from multiplex.

To compare relative size requirements of adding this new file, this is from an example dataset:
scaled.expt (207.8 kB)
scaled.mtz (504.6 kB)
scaled.refl (16.0 MB)
scaled.sca (256.9 kB) 

I23 have also confirmed that they don't need this output to pipeline-final at this stage. 