### PR TITLE
Increase log verbosity for bridge services

### DIFF
--- a/src/dlstbx/services/bridge.py
+++ b/src/dlstbx/services/bridge.py
@@ -33,7 +33,9 @@ class DLSBridge(CommonService):
     def receive_msg(self, header, message, args):
         send_to = args
         if send_to:
-            self.log.info("Shuttling message to rabbitmq queue %s", send_to)
+            self.log.info(
+                f"Shuttling message to rabbitmq queue {send_to}\nMessage content: {message}\nHeaders: {header}"
+            )
             try:
                 self.pika_transport.send(
                     send_to,

--- a/src/dlstbx/services/bridge_reverse.py
+++ b/src/dlstbx/services/bridge_reverse.py
@@ -34,7 +34,9 @@ class DLSReverseBridge(CommonService):
         send_to = args
         if send_to:
             try:
-                self.log.info("Shuttling message to ActiveMQ queue %s", send_to)
+                self.log.info(
+                    f"Shuttling message to ActiveMQ queue {send_to}\nMessage content: {message}\nHeaders: {header}"
+                )
                 if send_to == "darc.dropzone":
                     # Archiving queue: expect a bytestring and
                     # don't send to zocalo namespace


### PR DESCRIPTION
Some messages are still going via the bridge and bridge_reverse services but it is difficult/not possible to track the origin of these messages currently. In order to track down and get rid of any last things using ActiveMQ in zocalo, this PR adds the message content and headers to the logs so that the source of messages should be easier to identify. 