### PR TITLE
Handle removal of pixelsPerMicron grid_info columns

### DIFF
--- a/requirements.conda.txt
+++ b/requirements.conda.txt
@@ -1,6 +1,6 @@
 drmaa
 hdf5plugin
-ispyb>=11.1.2
+ispyb>=11.2.0
 junit-xml>=1.9
 marshmallow-sqlalchemy
 minio>=7.1.0

--- a/requirements.conda.txt
+++ b/requirements.conda.txt
@@ -1,6 +1,6 @@
 drmaa
 hdf5plugin
-ispyb>=11.2.0
+ispyb>=12.0.0
 junit-xml>=1.9
 marshmallow-sqlalchemy
 minio>=7.1.0

--- a/src/dlstbx/services/xray_centering.py
+++ b/src/dlstbx/services/xray_centering.py
@@ -37,23 +37,6 @@ class GridInfo(pydantic.BaseModel):
     def image_count(self) -> int:
         return self.steps_x * self.steps_y
 
-    @pydantic.model_validator(mode="before")
-    def handle_legacy_pixels_per_micron(cls, values):
-        # The field pixelsPerMicron{X,Y} was renamed to micronsPerPixel{X,Y}
-        # to correctly match the units of the value stored therein.
-        # For an overlapping period we may have to handle both columns until
-        # GDA has been updated on all beamlines to insert the correct column
-        # into the database.
-        # See also https://jira.diamond.ac.uk/browse/LIMS-464
-        for axis in "XY":
-            if (
-                values.get(f"micronsPerPixel{axis}") is None
-                and f"pixelsPerMicron{axis}" in values
-            ):
-                values[f"micronsPerPixel{axis}"] = values.get(f"pixelsPerMicron{axis}")
-                del values[f"pixelsPerMicron{axis}"]
-        return values
-
 
 class Parameters(pydantic.BaseModel):
     "Recipe parameters used by the X-ray centering service"

--- a/tests/ispybtbx/test_ispyb.py
+++ b/tests/ispybtbx/test_ispyb.py
@@ -362,16 +362,18 @@ def test_filter_function(db_session):
     param = {"ispyb_dcid": ds["i19_screening"]}
     msg, param = ispyb_filter(msg, param, db_session)
 
+
 def test_get_detectorname(db_session):
     test_data = {
-        "i03" : {"dcid" : 19714078, "expected" : "Eiger16M"},
-        "i24" : {"dcid" : 16030696, "expected" : "Eiger9MCdTe"}
+        "i03": {"dcid": 19714078, "expected": "Eiger16M"},
+        "i24": {"dcid": 16030696, "expected": "Eiger9MCdTe"},
     }
     for d in test_data.values():
         message = {}
         parameters = {"ispyb_dcid": d["dcid"]}
         message, parameters = ispyb_filter(message, parameters, db_session)
         assert parameters["ispyb_detectorname"] == d["expected"]
+
 
 def test_filter_function_with_load_config_file_timeout(monkeypatch, db_session):
     def mock_load_config_file(*args, **kwargs):
@@ -609,8 +611,8 @@ def test_get_gridscan_info(db_session):
             "snaked": 1,
             "orientation": "horizontal",
             "recordTimeStamp": "2021-03-05T15:29:20",
-            "pixelsPerMicronX": 0.566,
-            "pixelsPerMicronY": 0.566,
+            "micronsPerPixelX": 0.566,
+            "micronsPerPixelY": 0.566,
             "steps_x": 27.0,
             "dx_mm": 0.02,
             "xOffset": None,

--- a/tests/services/test_xray_centering.py
+++ b/tests/services/test_xray_centering.py
@@ -10,26 +10,6 @@ from workflows.transport.offline_transport import OfflineTransport
 import dlstbx.services.xray_centering
 
 
-def test_grid_info_params_from_legacy_pixels_per_micron():
-    gridinfo = {
-        "orientation": "horizontal",
-        "snapshot_offsetYPixel": 57.0822,
-        "gridInfoId": 1337162,
-        "micronsPerPixelX": None,
-        "micronsPerPixelY": None,
-        "dx_mm": 0.04,
-        "steps_y": 5.0,
-        "pixelsPerMicronX": 0.438,
-        "steps_x": 7.0,
-        "pixelsPerMicronY": 0.438,
-        "snaked": 1,
-        "snapshot_offsetXPixel": 79.9863,
-        "dy_mm": 0.04,
-    }
-    params = dlstbx.services.xray_centering.GridInfo(**gridinfo)
-    assert params.micronsPerPixelX == params.micronsPerPixelY == 0.438
-
-
 def generate_recipe_message(parameters, gridinfo):
     """Helper function for tests."""
     message = {


### PR DESCRIPTION
The erroneously named pixelsPerMicron columns of the GridInfo table in ISPyB are set to be removed, with all legacy data migrated to the micronsPerPixel columns. A new ispyb api version (12.0.0) has been released with these columns removed from the schema. Services that query this table will need to be updated to this version of the api to avoid crashing when trying to find columns that no longer exist.

This PR also removes legacy code relating to these old columns and also updates tests to point to the new columns. 