### PR TITLE
Don't create archiver dropfiles for forbidden visits

### DIFF
--- a/src/dlstbx/services/archiver.py
+++ b/src/dlstbx/services/archiver.py
@@ -6,6 +6,7 @@ import os
 import os.path
 import xml.etree.ElementTree as ET
 from datetime import datetime
+from pathlib import Path
 
 import workflows.recipe
 from workflows.services.common_service import CommonService
@@ -166,11 +167,12 @@ class DLSArchiver(CommonService):
 
         file_range_limit = int(settings.get("limit-files", 0))
 
-        filepaths = params["pattern"].split("/")
+        filepath = Path(params["pattern"])
+        dataset_name = Path(*filepath.parts[6:-1]).as_posix() or "topdir"
         beamline = params["beamline"]
         visit_id = params["visit"]
 
-        df = Dropfile(visit_id.upper(), beamline, "/".join(filepaths[6:-1]) or "topdir")
+        df = Dropfile(visit_id.upper(), beamline, dataset_name)
 
         message_out = {"success": 0, "failed": 0}
         files_not_found = []
@@ -317,9 +319,10 @@ class DLSArchiver(CommonService):
             self._transport.transaction_commit(txn)
             return
 
-        filepaths = filelist[0].split("/")
+        filepath = Path(filelist[0])
+        dataset_name = Path(*filepath.parts[6:-1]).as_posix() or "topdir"
         # Archive files
-        df = Dropfile(visit_id.upper(), beamline, "/".join(filepaths[6:-1]) or "topdir")
+        df = Dropfile(visit_id.upper(), beamline, dataset_name)
 
         message_out = {"success": 0, "failed": 0}
         files_not_found = []

--- a/src/dlstbx/services/archiver.py
+++ b/src/dlstbx/services/archiver.py
@@ -167,7 +167,8 @@ class DLSArchiver(CommonService):
         file_range_limit = int(settings.get("limit-files", 0))
 
         filepaths = params["pattern"].split("/")
-        _, _, beamline, _, _, visit_id = filepaths[0:6]
+        beamline = params["beamline"]
+        visit_id = params["visit"]
 
         df = Dropfile(visit_id.upper(), beamline, "/".join(filepaths[6:-1]) or "topdir")
 
@@ -279,7 +280,6 @@ class DLSArchiver(CommonService):
 
         # Extract parameters
         params = rw.recipe_step["parameters"]
-
         if isinstance(message, dict):
             multipart = message.get("archive-multipart", 1)
             filelist = message.get("filelist", params.get("filelist", []))

--- a/src/dlstbx/services/archiver.py
+++ b/src/dlstbx/services/archiver.py
@@ -132,6 +132,12 @@ class DLSArchiver(CommonService):
             group = list(group)
             yield group[0][1], group[-1][1]
 
+    def visit_is_archivable(
+        self, visit: str, forbidden_visit_codes: tuple[str, ...]
+    ) -> bool:
+        """Check if the visit code of a visit is in the list of forbidden visit codes."""
+        return not visit.startswith(forbidden_visit_codes)
+
     def archive_dcid(self, rw, header, message):
         """Archive collected datafiles connected to a data collection."""
 
@@ -141,6 +147,15 @@ class DLSArchiver(CommonService):
 
         # Extract parameters from the recipe
         params = rw.recipe_step["parameters"]
+
+        forbidden_visit_codes = tuple(params.get("forbidden-visit-codes", ()))
+        if not self.visit_is_archivable(params["visit"], forbidden_visit_codes):
+            self.log.info(
+                f"Skipping archiving of {params['pattern']} because it is from a forbidden visit"
+            )
+            self._transport.transaction_commit(txn)
+            return
+
         self.log.info("Attempting to archive %s", params["pattern"])
 
         settings = params.copy()
@@ -264,6 +279,7 @@ class DLSArchiver(CommonService):
 
         # Extract parameters
         params = rw.recipe_step["parameters"]
+
         if isinstance(message, dict):
             multipart = message.get("archive-multipart", 1)
             filelist = message.get("filelist", params.get("filelist", []))
@@ -287,24 +303,21 @@ class DLSArchiver(CommonService):
         )
         file_range_limit = int(params.get("limit-files", 0))
 
-        filepaths = filelist[0].split("/")
-        beamline = "unknown"
-        visit_id = "unknown"
-        try:
-            if filepaths[1:3] == ["dls", "mx"]:
-                beamline = "i02-2"  # VMXi currently only beamline with new visit path structure
-            else:
-                beamline = filepaths[2]
-            visit_id = filepaths[5]
-        except IndexError:
-            pass
-        visit_id = params.get("visit", visit_id)
-        beamline = params.get("beamline", beamline)
-
         # Conditionally acknowledge receipt of the message
         txn = self._transport.transaction_begin(subscription_id=header["subscription"])
         self._transport.ack(header, transaction=txn)
 
+        visit_id = params["visit"]
+        beamline = params["beamline"]
+        forbidden_visit_codes = tuple(params.get("forbidden-visit-codes", ()))
+        if not self.visit_is_archivable(visit_id, forbidden_visit_codes):
+            self.log.info(
+                f"Skipping archiving of {filelist} because it is from a forbidden visit"
+            )
+            self._transport.transaction_commit(txn)
+            return
+
+        filepaths = filelist[0].split("/")
         # Archive files
         df = Dropfile(visit_id.upper(), beamline, "/".join(filepaths[6:-1]) or "topdir")
 

--- a/src/dlstbx/services/archiver.py
+++ b/src/dlstbx/services/archiver.py
@@ -156,7 +156,9 @@ class DLSArchiver(CommonService):
         params = rw.recipe_step["parameters"]
 
         allowed_industrial_visit_codes = tuple(
-            params.get("allowed-industrial-visit-codes", ())
+            self.config.storage.get(
+                "zocalo.archiver.allowed_industrial_visit_codes", []
+            )
         )
         if not self.visit_is_archivable(
             params["visit"], allowed_industrial_visit_codes
@@ -322,7 +324,9 @@ class DLSArchiver(CommonService):
         visit_id = params["visit"]
         beamline = params["beamline"]
         allowed_industrial_visit_codes = tuple(
-            params.get("allowed-industrial-visit-codes", ())
+            self.config.storage.get(
+                "zocalo.archiver.allowed_industrial_visit_codes", []
+            )
         )
         if not self.visit_is_archivable(visit_id, allowed_industrial_visit_codes):
             self.log.info(

--- a/src/dlstbx/services/archiver.py
+++ b/src/dlstbx/services/archiver.py
@@ -11,6 +11,8 @@ from pathlib import Path
 import workflows.recipe
 from workflows.services.common_service import CommonService
 
+from dlstbx.util import INDUSTRIAL_CODES
+
 
 class Dropfile:
     """A class encapsulating the XML dropfile tree as it is built up."""
@@ -134,10 +136,14 @@ class DLSArchiver(CommonService):
             yield group[0][1], group[-1][1]
 
     def visit_is_archivable(
-        self, visit: str, forbidden_visit_codes: tuple[str, ...]
+        self, visit: str, allowed_industrial_visit_codes: tuple[str, ...]
     ) -> bool:
-        """Check if the visit code of a visit is in the list of forbidden visit codes."""
-        return not visit.startswith(forbidden_visit_codes)
+        """Return false if visit has an industrial code that is not in the list of allowed industrial visit codes."""
+        if visit.startswith(tuple(INDUSTRIAL_CODES)) and not visit.startswith(
+            allowed_industrial_visit_codes
+        ):
+            return False
+        return True
 
     def archive_dcid(self, rw, header, message):
         """Archive collected datafiles connected to a data collection."""
@@ -149,8 +155,12 @@ class DLSArchiver(CommonService):
         # Extract parameters from the recipe
         params = rw.recipe_step["parameters"]
 
-        forbidden_visit_codes = tuple(params.get("forbidden-visit-codes", ()))
-        if not self.visit_is_archivable(params["visit"], forbidden_visit_codes):
+        allowed_industrial_visit_codes = tuple(
+            params.get("allowed-industrial-visit-codes", ())
+        )
+        if not self.visit_is_archivable(
+            params["visit"], allowed_industrial_visit_codes
+        ):
             self.log.info(
                 f"Skipping archiving of {params['pattern']} because it is from a forbidden visit"
             )
@@ -311,8 +321,10 @@ class DLSArchiver(CommonService):
 
         visit_id = params["visit"]
         beamline = params["beamline"]
-        forbidden_visit_codes = tuple(params.get("forbidden-visit-codes", ()))
-        if not self.visit_is_archivable(visit_id, forbidden_visit_codes):
+        allowed_industrial_visit_codes = tuple(
+            params.get("allowed-industrial-visit-codes", ())
+        )
+        if not self.visit_is_archivable(visit_id, allowed_industrial_visit_codes):
             self.log.info(
                 f"Skipping archiving of {filelist} because it is from a forbidden visit"
             )

--- a/tests/services/test_archiver.py
+++ b/tests/services/test_archiver.py
@@ -373,39 +373,6 @@ class TestArchiverDCID:
         )
 
 
-class TestVisitValidation:
-    """Tests for visit code validation."""
-
-    def test_visit_is_archivable_allowed_visit(self, archiver_service):
-        """Test that allowed visit codes pass validation."""
-        result = archiver_service.visit_is_archivable("cm00001-1", ("TEST", "SKIP"))
-        assert result is True
-
-    def test_visit_is_archivable_forbidden_visit(self, archiver_service):
-        """Test that forbidden visit codes fail validation."""
-        result = archiver_service.visit_is_archivable("TEST-1", ("TEST", "SKIP"))
-        assert result is False
-
-    def test_visit_is_archivable_empty_forbidden_list(self, archiver_service):
-        """Test that all visits are allowed when forbidden list is empty."""
-        result = archiver_service.visit_is_archivable("TEST-1", ())
-        assert result is True
-
-    def test_visit_is_archivable_partial_match(self, archiver_service):
-        """Test that only prefix matching counts."""
-        # TEST-1 should match forbidden code TEST
-        result = archiver_service.visit_is_archivable("TEST-1", ("TEST",))
-        assert result is False
-
-        # TESTING-1 should match forbidden code TEST (starts with TEST)
-        result = archiver_service.visit_is_archivable("TESTING-1", ("TEST",))
-        assert result is False
-
-        # NOTTEST-1 should NOT match forbidden code TEST
-        result = archiver_service.visit_is_archivable("NOTTEST-1", ("TEST",))
-        assert result is True
-
-
 class TestDropfileGeneration:
     """Tests for dropfile XML generation."""
 

--- a/tests/services/test_archiver.py
+++ b/tests/services/test_archiver.py
@@ -1,0 +1,462 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from workflows.recipe.wrapper import RecipeWrapper
+from workflows.transport.offline_transport import OfflineTransport
+
+from dlstbx.services.archiver import DLSArchiver, Dropfile
+
+
+@pytest.fixture
+def mock_transport():
+    """Create a mock transport object."""
+    transport = mock.Mock()
+    txn = mock.Mock()
+    transport.transaction_begin.return_value = txn
+    return transport, txn
+
+
+@pytest.fixture
+def archiver_service(mock_transport):
+    """Create a DLSArchiver service instance with mocked transport."""
+    transport, _ = mock_transport
+    service = DLSArchiver()
+    service._transport = transport
+    return service
+
+
+def create_test_files(tmp_path, file_list):
+    """Helper to create test files in tmp_path."""
+    files = []
+    for filename in file_list:
+        filepath = tmp_path / filename
+        filepath.parent.mkdir(parents=True, exist_ok=True)
+        filepath.write_text(f"Content of {filename}")
+        files.append(str(filepath))
+    return files
+
+
+def create_recipe_message_filelist(parameters, files):
+    """Create a recipe message for filelist archiving."""
+    message = {
+        "recipe": {
+            "1": {
+                "service": "DLS Archiver",
+                "queue": "archive.filelist",
+                "parameters": parameters,
+            },
+        },
+        "recipe-pointer": "1",
+        "recipe-path": [],
+        "environment": {
+            "ID": mock.sentinel.GUID,
+            "source": mock.sentinel.source,
+            "timestamp": mock.sentinel.timestamp,
+        },
+        "payload": {"filelist": files},
+    }
+    return message
+
+
+def create_recipe_message_dcid(parameters):
+    """Create a recipe message for dcid archiving."""
+    message = {
+        "recipe": {
+            "1": {
+                "service": "DLS Archiver",
+                "queue": "archive.pattern",
+                "parameters": parameters,
+            },
+        },
+        "recipe-pointer": "1",
+        "recipe-path": [],
+        "environment": {
+            "ID": mock.sentinel.GUID,
+            "source": mock.sentinel.source,
+            "timestamp": mock.sentinel.timestamp,
+        },
+        "payload": {},
+    }
+    return message
+
+
+class TestArchiverFilelist:
+    """Tests for the archive_filelist method."""
+
+    def test_archive_filelist_creates_dropfile(
+        self, archiver_service, mock_transport, tmp_path
+    ):
+        """Test that a dropfile is created when valid files are provided."""
+        transport, txn = mock_transport
+        archiver_service._transport = transport
+
+        # Create test files
+        files = create_test_files(tmp_path, ["file1.txt", "file2.txt"])
+
+        # Create recipe parameters
+        dropfile_path = tmp_path / "dropfile.xml"
+        parameters = {
+            "visit": "cm00001-1",
+            "beamline": "i03",
+            "dropfile": str(dropfile_path),
+            "filelist": files,
+        }
+
+        # Create message
+        message = create_recipe_message_filelist(parameters, files)
+        header = {
+            "message-id": "test-message-id",
+            "subscription": "test-subscription",
+        }
+
+        # Create wrapper and call method
+        rw = RecipeWrapper(message=message, transport=OfflineTransport())
+        rw._transport = OfflineTransport()
+        archiver_service.archive_filelist(rw, header, message.get("payload"))
+
+        # Verify dropfile was created
+        assert dropfile_path.exists(), "Dropfile should be created"
+
+        # Verify content is XML
+        content = dropfile_path.read_text()
+        assert "<?xml version" in content
+        assert "CM00001" in content  # Visit codes are converted to uppercase
+        assert "i03" in content
+
+    def test_archive_filelist_with_forbidden_visit_code(
+        self, archiver_service, mock_transport, tmp_path
+    ):
+        """Test that no dropfile is created for forbidden visit codes."""
+        transport, txn = mock_transport
+        archiver_service._transport = transport
+
+        # Create test files
+        files = create_test_files(tmp_path, ["file1.txt"])
+
+        # Create recipe parameters with forbidden visit code
+        dropfile_path = tmp_path / "dropfile.xml"
+        parameters = {
+            "visit": "in12345-1",
+            "beamline": "i03",
+            "dropfile": str(dropfile_path),
+            "filelist": files,
+            "forbidden-visit-codes": ["in", "il"],
+        }
+
+        # Create message
+        message = create_recipe_message_filelist(parameters, files)
+        header = {
+            "message-id": "test-message-id",
+            "subscription": "test-subscription",
+        }
+
+        # Create wrapper and call method
+        rw = RecipeWrapper(message=message, transport=OfflineTransport())
+        rw._transport = OfflineTransport()
+        archiver_service.archive_filelist(rw, header, message.get("payload"))
+
+        # Verify no dropfile was created
+        assert not dropfile_path.exists(), (
+            "Dropfile should not be created for forbidden visit"
+        )
+
+        # Verify transaction was committed
+        transport.transaction_commit.assert_called_with(txn)
+
+    def test_archive_filelist_empty_files_list(self, archiver_service, mock_transport):
+        """Test that empty file list is rejected."""
+        transport, txn = mock_transport
+        archiver_service._transport = transport
+
+        # Create recipe parameters with empty file list
+        parameters = {
+            "visit": "cm00001-1",
+            "beamline": "i03",
+            "filelist": [],
+        }
+
+        # Create message with empty filelist
+        message = create_recipe_message_filelist(parameters, [])
+        header = {
+            "message-id": "test-message-id",
+            "subscription": "test-subscription",
+        }
+
+        # Create wrapper and call method
+        rw = RecipeWrapper(message=message, transport=OfflineTransport())
+        rw._transport = OfflineTransport()
+        archiver_service.archive_filelist(rw, header, message.get("payload"))
+
+        # Verify NACK was called
+        transport.nack.assert_called_once_with(header)
+
+    def test_archive_filelist_missing_files(
+        self, archiver_service, mock_transport, tmp_path
+    ):
+        """Test that missing files are handled correctly."""
+        transport, txn = mock_transport
+        archiver_service._transport = transport
+
+        # Create only one test file
+        files = create_test_files(tmp_path, ["file1.txt"])
+        # Add a missing file to the list
+        missing_file = str(tmp_path / "missing.txt")
+        files.append(missing_file)
+
+        # Create recipe parameters
+        dropfile_path = tmp_path / "dropfile.xml"
+        parameters = {
+            "visit": "cm00001-1",
+            "beamline": "i03",
+            "dropfile": str(dropfile_path),
+            "filelist": files,
+        }
+
+        # Create message
+        message = create_recipe_message_filelist(parameters, files)
+        header = {
+            "message-id": "test-message-id",
+            "subscription": "test-subscription",
+        }
+
+        # Create wrapper and call method
+        rw = RecipeWrapper(message=message, transport=OfflineTransport())
+        rw._transport = OfflineTransport()
+        archiver_service.archive_filelist(rw, header, message.get("payload"))
+
+        # Verify dropfile was still created
+        assert dropfile_path.exists(), (
+            "Dropfile should be created even with missing files"
+        )
+
+
+class TestArchiverDCID:
+    """Tests for the archive_dcid method."""
+
+    def test_archive_dcid_creates_dropfile(
+        self, archiver_service, mock_transport, tmp_path
+    ):
+        """Test that a dropfile is created for valid dcid archiving."""
+        transport, txn = mock_transport
+        archiver_service._transport = transport
+
+        # Create test files matching a pattern
+        image_dir = (
+            tmp_path / "data" / "cm" / "cm00001" / "i03" / "2024" / "Jan" / "cm00001-1"
+        )
+        image_dir.mkdir(parents=True, exist_ok=True)
+
+        # Create a few test image files
+        pattern = str(image_dir / "image_%06d.h5")
+        for i in range(1, 4):
+            filepath = image_dir / f"image_{i:06d}.h5"
+            filepath.write_text(f"Image data {i}")
+
+        # Create recipe parameters
+        dropfile_path = tmp_path / "dropfile.xml"
+        parameters = {
+            "visit": "cm00001-1",
+            "beamline": "i23",
+            "pattern": pattern,
+            "pattern-start": "1",
+            "pattern-end": "3",
+            "dropfile": str(dropfile_path),
+        }
+
+        # Create message
+        message = create_recipe_message_dcid(parameters)
+        header = {
+            "message-id": "test-message-id",
+            "subscription": "test-subscription",
+        }
+
+        # Create wrapper and call method
+        rw = RecipeWrapper(message=message, transport=OfflineTransport())
+        rw._transport = OfflineTransport()
+        archiver_service.archive_dcid(rw, header, message.get("payload"))
+
+        # Verify dropfile was created
+        assert dropfile_path.exists(), "Dropfile should be created"
+
+        # Verify content
+        content = dropfile_path.read_text()
+        assert "<?xml version" in content
+        assert "CM00001" in content
+        assert "i23" in content
+
+    def test_archive_dcid_with_forbidden_visit_code(
+        self, archiver_service, mock_transport, tmp_path
+    ):
+        """Test that no dropfile is created for forbidden visit codes in dcid."""
+        transport, txn = mock_transport
+        archiver_service._transport = transport
+
+        # Create test files
+        image_dir = (
+            tmp_path / "data" / "cm" / "TEST" / "i03" / "2024" / "Jan" / "TEST-1"
+        )
+        image_dir.mkdir(parents=True, exist_ok=True)
+        pattern = str(image_dir / "image_%06d.h5")
+        for i in range(1, 2):
+            filepath = image_dir / f"image_{i:06d}.h5"
+            filepath.write_text(f"Image data {i}")
+
+        # Create recipe parameters with forbidden visit code
+        dropfile_path = tmp_path / "dropfile.xml"
+        parameters = {
+            "visit": "in12345-1",
+            "pattern": pattern,
+            "pattern-start": "1",
+            "pattern-end": "1",
+            "dropfile": str(dropfile_path),
+            "forbidden-visit-codes": ["in", "il"],
+        }
+
+        # Create message
+        message = create_recipe_message_dcid(parameters)
+        header = {
+            "message-id": "test-message-id",
+            "subscription": "test-subscription",
+        }
+
+        # Create wrapper and call method
+        rw = RecipeWrapper(message=message, transport=OfflineTransport())
+        rw._transport = OfflineTransport()
+        archiver_service.archive_dcid(rw, header, message.get("payload"))
+
+        # Verify no dropfile was created
+        assert not dropfile_path.exists(), (
+            "Dropfile should not be created for forbidden visit"
+        )
+
+        # Verify transaction was committed
+        transport.transaction_commit.assert_called_with(txn)
+
+    def test_archive_dcid_no_files_found(
+        self, archiver_service, mock_transport, tmp_path
+    ):
+        """Test behavior when no files match the pattern."""
+        transport, txn = mock_transport
+        archiver_service._transport = transport
+
+        # Create a pattern that doesn't match any files
+        pattern = str(tmp_path / "nonexistent" / "image_%06d.h5")
+
+        # Create recipe parameters
+        dropfile_path = tmp_path / "dropfile.xml"
+        parameters = {
+            "visit": "cm00001-1",
+            "beamline": "i23",
+            "pattern": pattern,
+            "pattern-start": "1",
+            "pattern-end": "3",
+            "dropfile": str(dropfile_path),
+        }
+
+        # Create message
+        message = create_recipe_message_dcid(parameters)
+        header = {
+            "message-id": "test-message-id",
+            "subscription": "test-subscription",
+        }
+
+        # Create wrapper and call method
+        rw = RecipeWrapper(message=message, transport=OfflineTransport())
+        rw._transport = OfflineTransport()
+        archiver_service.archive_dcid(rw, header, message.get("payload"))
+
+        # Verify no dropfile was created (empty dropfile is skipped)
+        assert not dropfile_path.exists(), (
+            "Dropfile should not be created when no files found"
+        )
+
+
+class TestVisitValidation:
+    """Tests for visit code validation."""
+
+    def test_visit_is_archivable_allowed_visit(self, archiver_service):
+        """Test that allowed visit codes pass validation."""
+        result = archiver_service.visit_is_archivable("cm00001-1", ("TEST", "SKIP"))
+        assert result is True
+
+    def test_visit_is_archivable_forbidden_visit(self, archiver_service):
+        """Test that forbidden visit codes fail validation."""
+        result = archiver_service.visit_is_archivable("TEST-1", ("TEST", "SKIP"))
+        assert result is False
+
+    def test_visit_is_archivable_empty_forbidden_list(self, archiver_service):
+        """Test that all visits are allowed when forbidden list is empty."""
+        result = archiver_service.visit_is_archivable("TEST-1", ())
+        assert result is True
+
+    def test_visit_is_archivable_partial_match(self, archiver_service):
+        """Test that only prefix matching counts."""
+        # TEST-1 should match forbidden code TEST
+        result = archiver_service.visit_is_archivable("TEST-1", ("TEST",))
+        assert result is False
+
+        # TESTING-1 should match forbidden code TEST (starts with TEST)
+        result = archiver_service.visit_is_archivable("TESTING-1", ("TEST",))
+        assert result is False
+
+        # NOTTEST-1 should NOT match forbidden code TEST
+        result = archiver_service.visit_is_archivable("NOTTEST-1", ("TEST",))
+        assert result is True
+
+
+class TestDropfileGeneration:
+    """Tests for dropfile XML generation."""
+
+    def test_dropfile_basic_structure(self, tmp_path):
+        """Test that dropfile creates valid XML structure."""
+        # Create test file
+        testfile = tmp_path / "testdata.h5"
+        testfile.write_text("test data")
+
+        # Create dropfile
+        df = Dropfile("cm00001-1", "i03", "testdir")
+        df.add(str(testfile))
+        df.close()
+
+        # Get XML string
+        xml_str = df.to_string().decode("latin-1")
+
+        # Verify structure
+        assert '<?xml version="1.0" ?>' in xml_str
+        assert "<icat" in xml_str
+        assert "<visit_id>CM00001-1</visit_id>" in xml_str
+        assert "<instrument>i03</instrument>" in xml_str
+        assert "<name>testdata.h5</name>" in xml_str
+        assert f"<location>{str(testfile)}</location>" in xml_str
+
+    def test_dropfile_multiple_files(self, tmp_path):
+        """Test dropfile with multiple files."""
+        # Create test files
+        testfiles = []
+        for i in range(3):
+            testfile = tmp_path / f"data_{i}.h5"
+            testfile.write_text(f"test data {i}")
+            testfiles.append(str(testfile))
+
+        # Create dropfile
+        df = Dropfile("cm00001-1", "i03", "testdir")
+        for testfile in testfiles:
+            df.add(testfile)
+        df.close()
+
+        # Get XML string
+        xml_str = df.to_string().decode("latin-1")
+
+        # Verify all files are in the XML
+        for testfile in testfiles:
+            assert f"<name>data_{testfiles.index(testfile)}.h5</name>" in xml_str
+
+    def test_dropfile_visit_uppercase_conversion(self):
+        """Test that visit codes are converted to uppercase in dropfile."""
+        df = Dropfile("cm00001-1", "i03", "testdir")
+        df.close()
+
+        xml_str = df.to_string().decode("latin-1")
+        assert "<visit_id>CM00001-1</visit_id>" in xml_str

--- a/tests/services/test_archiver.py
+++ b/tests/services/test_archiver.py
@@ -135,14 +135,14 @@ class TestArchiverFilelist:
         # Create test files
         files = create_test_files(tmp_path, ["file1.txt"])
 
-        # Create recipe parameters with forbidden visit code
+        # Create recipe parameters with forbidden industrial visit code
         dropfile_path = tmp_path / "dropfile.xml"
         parameters = {
             "visit": "in12345-1",
             "beamline": "i03",
             "dropfile": str(dropfile_path),
             "filelist": files,
-            "forbidden-visit-codes": ["in", "il"],
+            "allowed-industrial-visit-codes": [],
         }
 
         # Create message
@@ -160,6 +160,46 @@ class TestArchiverFilelist:
         # Verify no dropfile was created
         assert not dropfile_path.exists(), (
             "Dropfile should not be created for forbidden visit"
+        )
+
+        # Verify transaction was committed
+        transport.transaction_commit.assert_called_with(txn)
+
+    def test_archive_filelist_with_allowed_industrial_visit_code(
+        self, archiver_service, mock_transport, tmp_path
+    ):
+        """Test that a dropfile is created when an industrial visit is explicitly allowed."""
+        transport, txn = mock_transport
+        archiver_service._transport = transport
+
+        # Create test files
+        files = create_test_files(tmp_path, ["file1.txt", "file2.txt"])
+
+        # Create recipe parameters with allowed industrial visit code
+        dropfile_path = tmp_path / "dropfile.xml"
+        parameters = {
+            "visit": "in12345-1",
+            "beamline": "i03",
+            "dropfile": str(dropfile_path),
+            "filelist": files,
+            "allowed-industrial-visit-codes": ["in"],
+        }
+
+        # Create message
+        message = create_recipe_message_filelist(parameters, files)
+        header = {
+            "message-id": "test-message-id",
+            "subscription": "test-subscription",
+        }
+
+        # Create wrapper and call method
+        rw = RecipeWrapper(message=message, transport=OfflineTransport())
+        rw._transport = OfflineTransport()
+        archiver_service.archive_filelist(rw, header, message.get("payload"))
+
+        # Verify dropfile was created
+        assert dropfile_path.exists(), (
+            "Dropfile should be created for allowed industrial visit"
         )
 
         # Verify transaction was committed
@@ -303,7 +343,7 @@ class TestArchiverDCID:
             filepath = image_dir / f"image_{i:06d}.h5"
             filepath.write_text(f"Image data {i}")
 
-        # Create recipe parameters with forbidden visit code
+        # Create recipe parameters with forbidden industrial visit code
         dropfile_path = tmp_path / "dropfile.xml"
         parameters = {
             "visit": "in12345-1",
@@ -311,7 +351,7 @@ class TestArchiverDCID:
             "pattern-start": "1",
             "pattern-end": "1",
             "dropfile": str(dropfile_path),
-            "forbidden-visit-codes": ["in", "il"],
+            "allowed-industrial-visit-codes": [],
         }
 
         # Create message
@@ -329,6 +369,55 @@ class TestArchiverDCID:
         # Verify no dropfile was created
         assert not dropfile_path.exists(), (
             "Dropfile should not be created for forbidden visit"
+        )
+
+        # Verify transaction was committed
+        transport.transaction_commit.assert_called_with(txn)
+
+    def test_archive_dcid_with_allowed_industrial_visit_code(
+        self, archiver_service, mock_transport, tmp_path
+    ):
+        """Test that a dropfile is created when an industrial visit is explicitly allowed."""
+        transport, txn = mock_transport
+        archiver_service._transport = transport
+
+        # Create test files
+        image_dir = (
+            tmp_path / "data" / "cm" / "TEST" / "i03" / "2024" / "Jan" / "TEST-1"
+        )
+        image_dir.mkdir(parents=True, exist_ok=True)
+        pattern = str(image_dir / "image_%06d.h5")
+        for i in range(1, 2):
+            filepath = image_dir / f"image_{i:06d}.h5"
+            filepath.write_text(f"Image data {i}")
+
+        # Create recipe parameters with allowed industrial visit code
+        dropfile_path = tmp_path / "dropfile.xml"
+        parameters = {
+            "visit": "in12345-1",
+            "beamline": "i03",
+            "pattern": pattern,
+            "pattern-start": "1",
+            "pattern-end": "1",
+            "dropfile": str(dropfile_path),
+            "allowed-industrial-visit-codes": ["in"],
+        }
+
+        # Create message
+        message = create_recipe_message_dcid(parameters)
+        header = {
+            "message-id": "test-message-id",
+            "subscription": "test-subscription",
+        }
+
+        # Create wrapper and call method
+        rw = RecipeWrapper(message=message, transport=OfflineTransport())
+        rw._transport = OfflineTransport()
+        archiver_service.archive_dcid(rw, header, message.get("payload"))
+
+        # Verify dropfile was created
+        assert dropfile_path.exists(), (
+            "Dropfile should be created for allowed industrial visit"
         )
 
         # Verify transaction was committed

--- a/tests/services/test_archiver.py
+++ b/tests/services/test_archiver.py
@@ -20,10 +20,15 @@ def mock_transport():
 
 @pytest.fixture
 def archiver_service(mock_transport):
-    """Create a DLSArchiver service instance with mocked transport."""
+    """Create a DLSArchiver service instance with mocked transport and config."""
     transport, _ = mock_transport
     service = DLSArchiver()
     service._transport = transport
+    service._environment = {
+        "config": mock.Mock(
+            storage={"zocalo.archiver.allowed_industrial_visit_codes": ["sw"]},
+        )
+    }
     return service
 
 
@@ -142,7 +147,6 @@ class TestArchiverFilelist:
             "beamline": "i03",
             "dropfile": str(dropfile_path),
             "filelist": files,
-            "allowed-industrial-visit-codes": [],
         }
 
         # Create message
@@ -178,11 +182,10 @@ class TestArchiverFilelist:
         # Create recipe parameters with allowed industrial visit code
         dropfile_path = tmp_path / "dropfile.xml"
         parameters = {
-            "visit": "in12345-1",
+            "visit": "sw12345-1",
             "beamline": "i03",
             "dropfile": str(dropfile_path),
             "filelist": files,
-            "allowed-industrial-visit-codes": ["in"],
         }
 
         # Create message
@@ -351,7 +354,6 @@ class TestArchiverDCID:
             "pattern-start": "1",
             "pattern-end": "1",
             "dropfile": str(dropfile_path),
-            "allowed-industrial-visit-codes": [],
         }
 
         # Create message
@@ -394,13 +396,12 @@ class TestArchiverDCID:
         # Create recipe parameters with allowed industrial visit code
         dropfile_path = tmp_path / "dropfile.xml"
         parameters = {
-            "visit": "in12345-1",
+            "visit": "sw12345-1",
             "beamline": "i03",
             "pattern": pattern,
             "pattern-start": "1",
             "pattern-end": "1",
             "dropfile": str(dropfile_path),
-            "allowed-industrial-visit-codes": ["in"],
         }
 
         # Create message


### PR DESCRIPTION
"il" and "in" visits should not be archived. The archiver service currently creates dropfiles for all visits and relies on the safeguards later in the process to stop these from being archived.

This PR adds a feature to specify forbidden visit codes in the recipe and avoids creating dropfiles if the visit starts with one of the forbidden codes.

Also adds tests for the archiver service. 