### PR TITLE
Add visit and beamline params to archiver system tests

### DIFF
--- a/src/dlstbx/system_test/archiver-partial.xml
+++ b/src/dlstbx/system_test/archiver-partial.xml
@@ -4,8 +4,8 @@
     <investigation>
       <!--Producer: Zocalo dlstbx.services.archiver-->
       <inv_number>DIALS</inv_number>
-      <visit_id>DIALS</visit_id>
-      <instrument>science</instrument>
+      <visit_id>MX12345-6</visit_id>
+      <instrument>i03</instrument>
       <title>dont need it</title>
       <inv_type>experiment</inv_type>
       <dataset>

--- a/src/dlstbx/system_test/archiver-success-part1.xml
+++ b/src/dlstbx/system_test/archiver-success-part1.xml
@@ -4,8 +4,8 @@
     <investigation>
       <!--Producer: Zocalo dlstbx.services.archiver-->
       <inv_number>DIALS</inv_number>
-      <visit_id>DIALS</visit_id>
-      <instrument>science</instrument>
+      <visit_id>MX12345-6</visit_id>
+      <instrument>i03</instrument>
       <title>dont need it</title>
       <inv_type>experiment</inv_type>
       <dataset>

--- a/src/dlstbx/system_test/archiver-success-part2.xml
+++ b/src/dlstbx/system_test/archiver-success-part2.xml
@@ -4,8 +4,8 @@
     <investigation>
       <!--Producer: Zocalo dlstbx.services.archiver-->
       <inv_number>DIALS</inv_number>
-      <visit_id>DIALS</visit_id>
-      <instrument>science</instrument>
+      <visit_id>MX12345-6</visit_id>
+      <instrument>i03</instrument>
       <title>dont need it</title>
       <inv_type>experiment</inv_type>
       <dataset>

--- a/src/dlstbx/system_test/archiver-success.xml
+++ b/src/dlstbx/system_test/archiver-success.xml
@@ -4,8 +4,8 @@
     <investigation>
       <!--Producer: Zocalo dlstbx.services.archiver-->
       <inv_number>DIALS</inv_number>
-      <visit_id>DIALS</visit_id>
-      <instrument>science</instrument>
+      <visit_id>MX12345-6</visit_id>
+      <instrument>i03</instrument>
       <title>dont need it</title>
       <inv_type>experiment</inv_type>
       <dataset>

--- a/src/dlstbx/system_test/archiver.py
+++ b/src/dlstbx/system_test/archiver.py
@@ -22,6 +22,8 @@ class ArchiverService(CommonSystemTest):
                     "pattern-start": 1,
                     "pattern-end": "10",
                     "dropfile-queue": self.target_queue,
+                    "visit": "mx12345-6",
+                    "beamline": "i03",
                 },
                 "output": 2,
             },
@@ -78,7 +80,8 @@ class ArchiverService(CommonSystemTest):
                 "queue": "archive.filelist",
                 "parameters": {
                     "filelist": files,
-                    "visit": "DIALS",
+                    "visit": "mx12345-6",
+                    "beamline": "i03",
                     "dropfile-queue": self.target_queue,
                 },
                 "output": 2,
@@ -134,6 +137,8 @@ class ArchiverService(CommonSystemTest):
                     "pattern-start": 1,
                     "pattern-end": "10",
                     "limit-files": 6,
+                    "visit": "mx12345-6",
+                    "beamline": "i03",
                 },
                 "output": 2,
             },
@@ -198,7 +203,12 @@ class ArchiverService(CommonSystemTest):
             1: {
                 "service": "DLS Archiver",
                 "queue": "archive.filelist",
-                "parameters": {"filelist": files, "visit": "DIALS", "limit-files": 6},
+                "parameters": {
+                    "filelist": files,
+                    "visit": "mx12345-6",
+                    "beamline": "i03",
+                    "limit-files": 6,
+                },
                 "output": 2,
             },
             2: {
@@ -262,6 +272,8 @@ class ArchiverService(CommonSystemTest):
                     "pattern-start": "40",
                     "pattern-end": 50,
                     "log-summary-warning-as-info": True,
+                    "visit": "mx12345-6",
+                    "beamline": "i03",
                 },
                 "output": {
                     "dropfile": 2,
@@ -327,7 +339,8 @@ class ArchiverService(CommonSystemTest):
                 "queue": "archive.filelist",
                 "parameters": {
                     "filelist": files,
-                    "visit": "DIALS",
+                    "visit": "mx12345-6",
+                    "beamline": "i03",
                     "log-summary-warning-as-info": True,
                 },
                 "output": 2,


### PR DESCRIPTION
Add newly required params to the system tests to stop them crashing the archiver service.