### PR TITLE
Fix check for swmr compatibility in h5 files

### DIFF
--- a/src/dlstbx/services/validation.py
+++ b/src/dlstbx/services/validation.py
@@ -86,7 +86,7 @@ class DLSValidation(CommonService):
 
         fail = functools.partial(self.fail_validation, rw, header, output)
 
-        # Verify HDF5 file version is _not_ compatible with HDF5 1.8 format
+        # Verify HDF5 file version is SWMR compatible (doesn't require SWMR mode to be enabled)
         if filename.endswith((".h5", ".nxs")):
             if not hdf5_util.is_readable(filename):
                 return fail(f"{filename} is an invalid HDF5 file")
@@ -106,17 +106,16 @@ class DLSValidation(CommonService):
                     return fail(
                         f"HDF5 file {filename} links to invalid file(s) {', '.join(errors)}"
                     )
-                hdf_18 = [
+                hdf_swmr_incompatible = [
                     link
                     for link, image_count in hdf5_util.find_all_references(
                         filename
                     ).items()
-                    if image_count and hdf5_util.is_HDF_1_8_compatible(link)
+                    if image_count and not hdf5_util.is_SWMR_compatible(link)
                 ]
-                if hdf_18:
+                if hdf_swmr_incompatible:
                     return fail(
-                        f"HDF5 file {filename} links to HDF5 1.8 format data in %s"
-                        % ", ".join(hdf_18)
+                        f"HDF5 file {filename} links to non-SWMR compatible file(s) {', '.join(hdf_swmr_incompatible)}"
                     )
                 try:
                     hdf5_util.validate_pixel_mask(filename)

--- a/src/dlstbx/util/hdf5.py
+++ b/src/dlstbx/util/hdf5.py
@@ -104,14 +104,15 @@ def is_readable(filename: str) -> bool:
         return False
 
 
-def is_HDF_1_8_compatible(filename: str) -> bool:
-    """Check if a file can be read with HDF 1.8. This excludes all SWMR formatted files."""
+def is_SWMR_compatible(filename: str) -> bool:
+    """Check if a file format is SWMR compatible by checking superblock version."""
 
-    try:
-        with h5py.File(filename, "r", libver=("earliest", "v108")):
-            return True
-    except OSError:
-        return False
+    with h5py.File(filename, "r") as f:
+        fcpl = f.id.get_create_plist()
+        # returns a tuple of (superblock_version, freelist_version, symbol_table_version, shared_header_version)
+        versions = fcpl.get_version()
+        superblock_version = versions[0]
+        return superblock_version >= 3
 
 
 def validate_pixel_mask(filename: str) -> bool:

--- a/tests/util/test_hdf5.py
+++ b/tests/util/test_hdf5.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 
+import h5py
 import pytest
 
 import dlstbx.util.hdf5
@@ -61,3 +62,15 @@ def test_validate_pixel_mask_shape_int64():
         dlstbx.util.hdf5.validate_pixel_mask(
             "/dls/mx/data/cm31104/cm31104-1/020222/RT/ToNV_WT/x_27_master.h5"
         )
+
+
+def test_is_SWMR_compatible(tmp_path):
+    # Test that the function correctly identifies SWMR compatible and incompatible files
+    swmr_compatible_file = tmp_path / "swmr_compatible.h5"
+    with h5py.File(swmr_compatible_file.as_posix(), "w", libver=("v110", "latest")):
+        pass
+    assert dlstbx.util.hdf5.is_SWMR_compatible(swmr_compatible_file.as_posix())
+    swmr_incompatible_file = tmp_path / "swmr_incompatible.h5"
+    with h5py.File(swmr_incompatible_file.as_posix(), "w", libver=("earliest", "v108")):
+        pass
+    assert not dlstbx.util.hdf5.is_SWMR_compatible(swmr_incompatible_file.as_posix())


### PR DESCRIPTION
The validation service checks files to ensure that the h5 files are not compatible with HDF5 versions <= 1.8, with the intention of ensuring that files are written in a SWMR compatible file format (SWMR was introduced in HDF5 1.10). The check (added in #25)  operated by trying to open the file using library version bounds of ("earliest", "v108") and would determine a file to be incompatible if an `OSError` was returned.

With the release of hdf5 library versions > 2.0, which the dials build now uses, the behaviour of `with h5py.File(filename, "r", libver=("earliest", "v108")):` has changed and will now successfully open files even if they contain/use objects/features incompatible with the older libraries, including swmr. This is because the intention of the libver bounds is to ensure library compatibility of new objects created thereafter and is not supposed to affect initial file access, but this was not implemented correctly in hdf5 < 2.0 (see [the discussion here](https://github.com/HDFGroup/hdf5/pull/4939) for details).

This PR fixes the check by instead finding the super block version of the hdf5 file. SWMR requires a superblock version >= 3, so this is used to determine whether the file is swmr compatible. The check does not establish whether the file is SWMR mode is enabled in the file.

This PR also adds a test for the SWMR compatibility check. 