### PR TITLE
Fix estimate transmission wrapper

### DIFF
--- a/src/dlstbx/wrapper/estimate_transmission.py
+++ b/src/dlstbx/wrapper/estimate_transmission.py
@@ -95,7 +95,7 @@ class EstimateTransmissionWrapper(Wrapper):
             {"parameters": {"scaled_transmission": float(scaled_transmission)}},
         )
 
-        max_pixel_count_pct = num_counts[-1] / trusted_range
+        max_pixel_count_pct = int(num_counts[-1]) / trusted_range
         if max_pixel_count_pct < 0.7:
             warning_level = 0
         elif max_pixel_count_pct < 0.85:


### PR DESCRIPTION
Fixing bug where num_counts is rarely interpreted as a string and causing an error