### PR TITLE
Allow msp thresholds to be set by recipe

### DIFF
--- a/src/dlstbx/services/xray_centering.py
+++ b/src/dlstbx/services/xray_centering.py
@@ -55,6 +55,8 @@ class Parameters(pydantic.BaseModel):
     msp_sample_ids: Optional[dict[int, int]] = {}
     threshold: pydantic.NonNegativeFloat = 0.25
     threshold_absolute: pydantic.NonNegativeFloat = 0
+    threshold_msp: pydantic.NonNegativeFloat = 0.25
+    threshold_absolute_msp: pydantic.NonNegativeFloat = 3
 
 
 class RecipeStep(pydantic.BaseModel):
@@ -283,11 +285,21 @@ class DLSXRayCentering(CommonService):
                         self.log.debug(f"{perm=}")
                         data = [data[p] for p in perm]
 
+                        if parameters.msp_sample_ids:
+                            self.log.debug(
+                                f"Applying multi-sample pin thresholds for sample IDs {parameters.msp_sample_ids}"
+                            )
+                            threshold = parameters.threshold_msp
+                            threshold_absolute = parameters.threshold_absolute_msp
+                        else:
+                            threshold = parameters.threshold
+                            threshold_absolute = parameters.threshold_absolute
+
                         result = dlstbx.util.xray_centering_3d.gridscan3d(
                             data=tuple(data),
                             sample_id=parameters.sample_id,
-                            threshold=parameters.threshold,
-                            threshold_absolute=parameters.threshold_absolute,
+                            threshold=threshold,
+                            threshold_absolute=threshold_absolute,
                             plot=False,
                             multipin_sample_ids=parameters.msp_sample_ids,
                             well_limits=well_limits,

--- a/src/dlstbx/util/xray_centering_3d.py
+++ b/src/dlstbx/util/xray_centering_3d.py
@@ -48,8 +48,6 @@ def gridscan3d(
     data: tuple[np.ndarray, ...],
     threshold: float = 0.25,
     threshold_absolute: float = 0,
-    threshold_msp: float = 0.25,
-    threshold_msp_absolute: float = 3,
     plot: bool = False,
     sample_id: int | None = None,
     multipin_sample_ids: dict[int, int] = {},
@@ -58,13 +56,19 @@ def gridscan3d(
     """
     3D gridscan analysis from 2 x 2D perpendicular gridscans.
 
-    Fitting routine finds each separate region of continuously connected data, filters
-    out any regions which do not have a voxel with intensity > threshold_absolute. Then,
-    for each of these regions, a relative threshold of the max voxel intensity for that
-    region is applied, with the aim to separate/disconnect peaks of intensity within the
-    region. Each continuously connected sub_region within the region after applying the
-    threshold is then found and is stored as grid_Scan result. The purpose of this second
-    step is to try and locate the individual centres of crystals that are close together.
+    Fitting routine first filters out any pixels from either gridscan with intensity
+    less than threshold_absolute, then constructs a pseudo-3D grid by taking the outer
+    product of the 2D scans. For multi-sample pins, any separate continuous regions of
+    signal are found first, whereas for single sample pins the entire 3D grid is treated
+    as a single region for the following steps. For each region, a relative threshold of
+    the max voxel intensity of the region is applied, with the aim to separate/disconnect
+    peaks of intensity within the region. Separate continuous sub-regions are then found
+    after applying the threshold, which are then stored as grid_scan results. The purpose
+    of this second step is to try and locate the individual centres of crystals that are
+    close together in the gridscan, which would be merged into a single region without
+    applying the relative threshold. For multi-sample pins, the centre of mass of the found
+    sub-regions are tagged with the corresponding sample_id by comparing the x-coordinate
+    to the well limits provided.
 
     Assumption: X is along the rotation axis, Y, Z are perpendicular
 
@@ -79,14 +83,9 @@ def gridscan3d(
     Args:
         data: A tuple of spot counts from 2 orthogonal 2D gridscans
         threshold: Mask out values less than this fraction of the maximum data value
-            in an identified region of the reconstructed 3d grid. Does not apply to
-            multi-sample pins.
+            in an identified region of the reconstructed 3d grid.
         threshold_absolute: filter out identified regions of continuous signal where the
             max value is less than this absolute value.
-        threshold_msp: Applies only to multi-sample pins. Mask out values less than this
-            fraction of the maximum data value in each continuous region of the reconstructed
-            3d grid.
-        threshold_msp_absolute: Applied instead of threshold_absolute for multi-sample pins.
         plot: Show interactive debug plots of the grid scan analysis (default=False)
         sample_id: The sample id attributed to the grid_scan. This will usually be the
             sample in sublocation 1 in the case of multi-sample pins.
@@ -102,11 +101,6 @@ def gridscan3d(
     assert len(data) == 2
     assert data[0].ndim == 2
     assert data[1].ndim == 2
-
-    # Use alternative thresholds for multi-sample pins
-    if multipin_sample_ids:
-        threshold = threshold_msp
-        threshold_absolute = threshold_msp_absolute
 
     # Apply absolute threshold to screen out noise.
     data[0][data[0] < threshold_absolute] = 0

--- a/tests/services/test_xray_centering.py
+++ b/tests/services/test_xray_centering.py
@@ -242,3 +242,98 @@ def test_xray_centering_3d(mocker):
         },
         transaction=mock.ANY,
     )
+
+
+def test_xray_centering_3d_multisample_pin(mocker):
+    dcids = (54321, 54324)
+    parameters = {
+        "dcid": f"{dcids[0]}",
+        "dcg_dcids": [dcids[1]],
+        "experiment_type": "Mesh3D",
+        "beamline": "i03",
+        "sample_id": 12345,
+        "msp_sample_ids": {1: 12345, 2: 12346, 3: 12347},
+        "loop_type": "multipin_3x4+2",
+        "threshold_msp": 0.25,
+        "threshold_absolute_msp": 3,
+    }
+
+    gridinfo = {
+        "dx_mm": 0.001,
+        "dy_mm": 0.001,
+        "gridInfoId": 1061461,
+        "orientation": "horizontal",
+        "micronsPerPixelX": 0.438,
+        "micronsPerPixelY": 0.438,
+        "snaked": 1,
+        "snapshot_offsetXPixel": 363.352,
+        "snapshot_offsetYPixel": 274.936,
+        "steps_x": 12.0,
+        "steps_y": 1.0,
+    }
+
+    t = OfflineTransport()
+    xc = dlstbx.services.xray_centering.DLSXRayCentering()
+    xc.transport = t
+    xc.start()
+    # fmt: off
+    spots_count_m45 = [0, 3, 3, 0, 0, 20, 10, 0, 0, 1, 0, 1]
+    spot_counts_p45 = [0, 3, 3, 0, 0, 10, 10, 0, 0, 1, 1, 1]
+    # fmt: on
+    m = generate_recipe_message(parameters, gridinfo)
+    rw = RecipeWrapper(message=m, transport=t)
+    message = {"n_spots_total": 10, "file-number": 1, "file-seen-at": time.time()}
+    header = {
+        "message-id": mock.sentinel,
+        "subscription": mock.sentinel,
+    }
+    send_to = mocker.spy(rw, "send_to")
+    for i, n_spots in enumerate(spots_count_m45):
+        message = {
+            "n_spots_total": n_spots,
+            "file-number": i + 1,
+            "file-seen-at": time.time(),
+        }
+        xc.add_pia_result(rw, header, message)
+    send_to.assert_not_called()
+
+    m = generate_recipe_message(
+        {**parameters, "dcg_dcids": [dcids[0]], "dcid": dcids[1]}, gridinfo
+    )
+    rw = RecipeWrapper(message=m, transport=t)
+    send_to = mocker.spy(rw, "send_to")
+    for i, n_spots in enumerate(spot_counts_p45):
+        message = {
+            "n_spots_total": n_spots,
+            "file-number": i + 1,
+            "file-seen-at": time.time(),
+        }
+        xc.add_pia_result(rw, header, message)
+    send_to.assert_called_with(
+        "success",
+        {
+            "results": [
+                {
+                    "max_voxel": (5, 0, 0),
+                    "max_count": 200.0,
+                    "n_voxels": 2,
+                    "total_count": 300.0,
+                    "centre_of_mass": mock.ANY,
+                    "bounding_box": ((5, 0, 0), (7, 1, 1)),
+                    "sample_id": 12346,
+                },
+                {
+                    "max_voxel": (1, 0, 0),
+                    "max_count": 9.0,
+                    "n_voxels": 2,
+                    "total_count": 18.0,
+                    "centre_of_mass": mock.ANY,
+                    "bounding_box": ((1, 0, 0), (3, 1, 1)),
+                    "sample_id": 12345,
+                },
+            ],
+            "status": "success",
+            "type": "3d",
+        },
+        transaction=mock.ANY,
+    )

--- a/tests/util/test_xray_centering_3d.py
+++ b/tests/util/test_xray_centering_3d.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -129,8 +130,8 @@ def test_gridscan3d_for_multipin_sample():
     # Fit peaks with multipin threshold parameters and check that correct results are obtained.
     results = dlstbx.util.xray_centering_3d.gridscan3d(
         data,
-        threshold_msp=0.25,
-        threshold_msp_absolute=3,
+        threshold=0.25,
+        threshold_absolute=3,
         sample_id=sample_id,
         plot=False,
         multipin_sample_ids=multipin_sample_ids,
@@ -140,7 +141,7 @@ def test_gridscan3d_for_multipin_sample():
     assert len(results) == 2
     expected_results = [
         {
-            "centre_of_mass": (5.833333333333333, 0.5, 0.5),
+            "centre_of_mass": mock.ANY,
             "max_voxel": (5, 0, 0),
             "max_count": 200.0,
             "n_voxels": 2,
@@ -149,7 +150,7 @@ def test_gridscan3d_for_multipin_sample():
             "bounding_box": ((5, 0, 0), (7, 1, 1)),
         },
         {
-            "centre_of_mass": (2.0, 0.5, 0.5),
+            "centre_of_mass": mock.ANY,
             "max_voxel": (1, 0, 0),
             "max_count": 9.0,
             "n_voxels": 2,


### PR DESCRIPTION
#371 added a separate xrc fitting routine for multi-sample pins. However, the msp specific thresholds required for the routine were not settable parameters in the xrc service and therefore could not be changed from the default values.

This PR removes the need fdor separate thresholds in the gridscan3d function itself and instead moves the selection of thresholds to the service. New optional parameters for msp thresholds are added to the service parameters, allowing them to be optionally set in the recipe step.

PR also adds a test for fitting multipin data via the xrc service and updates the util test of multipin fitting.