### PR TITLE
Stop generating unused diffraction previews

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -271,7 +271,6 @@ setup(
         ],
         "zocalo.services.images.plugins": [
             "diffraction = dlstbx.services.images:diffraction",
-            "thumbnail = dlstbx.services.images:thumbnail",
         ],
         "zocalo.wrappers": sorted(known_wrappers),
         "zocalo.mimas.handlers": sorted(mimas_scenario_handlers),

--- a/src/dlstbx/mimas/core.py
+++ b/src/dlstbx/mimas/core.py
@@ -142,16 +142,9 @@ def handle_eiger_end(
     scenario: mimas.MimasScenario,
     **kwargs,
 ) -> List[mimas.Invocation]:
-    stopped = scenario.runstatus == "DataCollection Stopped"
     tasks: List[mimas.Invocation] = [
         mimas.MimasRecipeInvocation(DCID=scenario.DCID, recipe="archive-nexus"),
     ]
-    if not stopped:
-        tasks.append(
-            mimas.MimasRecipeInvocation(
-                DCID=scenario.DCID, recipe="generate-diffraction-preview"
-            )
-        )
     return tasks
 
 
@@ -239,6 +232,9 @@ def handle_rotation_end(
         mimas.MimasRecipeInvocation(
             DCID=scenario.DCID,
             recipe=f"processing-rlv{suffix}",
+        ),
+        mimas.MimasRecipeInvocation(
+            DCID=scenario.DCID, recipe="generate-diffraction-preview"
         ),
     ]
 

--- a/src/dlstbx/mimas/i19.py
+++ b/src/dlstbx/mimas/i19.py
@@ -130,7 +130,6 @@ def handle_i19_end_eiger(
         for recipe in (
             "archive-nexus",
             "processing-rlv-eiger",
-            "generate-diffraction-preview",
             "strategy-screen19-eiger",
             "per-image-analysis-rotation-swmr-i19",
         )
@@ -140,6 +139,12 @@ def handle_i19_end_eiger(
 @mimas.match_specification(is_i19 & is_end & ~is_serial)
 def handle_i19_end(scenario: mimas.MimasScenario, **kwargs) -> List[mimas.Invocation]:
     tasks: List[mimas.Invocation] = []
+
+    tasks.append(
+        mimas.MimasRecipeInvocation(
+            DCID=scenario.DCID, recipe="generate-diffraction-preview"
+        )
+    )
 
     ParamTuple = Tuple[mimas.MimasISPyBParameter, ...]
     extra_params: List[ParamTuple] = [()]

--- a/src/dlstbx/mimas/vmxi.py
+++ b/src/dlstbx/mimas/vmxi.py
@@ -28,9 +28,6 @@ def handle_vmxi_end(
     **kwargs,
 ) -> List[mimas.Invocation]:
     return [
-        mimas.MimasRecipeInvocation(
-            DCID=scenario.DCID, recipe="generate-diffraction-preview"
-        ),
         mimas.MimasRecipeInvocation(DCID=scenario.DCID, recipe="archive-nexus"),
     ]
 
@@ -81,6 +78,10 @@ def handle_vmxi_rotation_scan(
         ),
         # mmcif-gen
         mimas.MimasRecipeInvocation(DCID=scenario.DCID, recipe="processing-mmcif-gen"),
+        # Diffraction preview
+        mimas.MimasRecipeInvocation(
+            DCID=scenario.DCID, recipe="generate-diffraction-preview"
+        ),
         # fast_dp
         mimas.MimasISPyBJobInvocation(
             DCID=scenario.DCID,

--- a/src/dlstbx/services/images.py
+++ b/src/dlstbx/services/images.py
@@ -8,7 +8,6 @@ import re
 import time
 from typing import Any, Callable, Dict, NamedTuple, Protocol
 
-import PIL.Image
 import procrunner
 import workflows.recipe
 from workflows.services.common_service import CommonService
@@ -31,7 +30,7 @@ PluginParameter = PluginInterface  # backwards-compatibility, 20210702
 
 class DLSImages(CommonService):
     """
-    A service that generates images and thumbnails.
+    A service that generates images.
     Plugin functions can be registered under the entry point
     'zocalo.services.images.plugins'. The contract is that a plugin function
     takes a single argument of type PluginInterface, and returns a truthy value
@@ -123,8 +122,6 @@ def diffraction(plugin: PluginInterface):
     if not os.path.exists(filename):
         logger.error("File %s not found", filename)
         return False
-    sizex = plugin.parameters("size-x", default=400)
-    sizey = plugin.parameters("size-y", default=192)
     output = plugin.parameters("output")
     if not output:
         # split off extension
@@ -140,9 +137,7 @@ def diffraction(plugin: PluginInterface):
         except OSError as e:
             if e.errno != errno.EEXIST:
                 raise
-    output_small = output[: output.rindex(".")] + ".thumb.jpeg"
 
-    start = time.perf_counter()
     result = procrunner.run(
         [
             "dials.export_bitmaps",
@@ -155,7 +150,7 @@ def diffraction(plugin: PluginInterface):
             'output.file="%s"' % output,
         ]
     )
-    export = time.perf_counter()
+
     if result.returncode:
         logger.error(
             f"Export of {filename} failed with exitcode {result.returncode}:\n"
@@ -165,45 +160,5 @@ def diffraction(plugin: PluginInterface):
     if not os.path.exists(output):
         logger.error("Output file %s not found", output)
         return False
-    with PIL.Image.open(output) as fh:
-        fh.thumbnail((sizex, sizey))
-        fh.save(output_small)
-    done = time.perf_counter()
 
-    logger.info(
-        "Created thumbnail %s -> %s (%.1f sec) -> %s (%.1f sec)",
-        filename,
-        output,
-        export - start,
-        output_small,
-        done - export,
-    )
-    return [output, output_small]
-
-
-def thumbnail(plugin: PluginInterface):
-    """Take a single file and create a smaller version of the same file."""
-    filename = plugin.parameters("file")
-    if not filename or filename == "None":
-        logger.debug("Skipping thumbnail generation: filename not specified")
-        return False
-    if not os.path.exists(filename):
-        logger.error("File %s not found", filename)
-        return False
-    sizex = plugin.parameters("size-x", default=400)
-    sizey = plugin.parameters("size-y", default=192)
-    output = plugin.parameters("output")
-    if not output:
-        # If not set add a 't' in front of the last '.' in the filename
-        output = (
-            filename[: filename.rindex(".")] + "t" + filename[filename.rindex(".") :]
-        )
-
-    start = time.perf_counter()
-    with PIL.Image.open(filename) as fh:
-        fh.thumbnail((sizex, sizey))
-        fh.save(output)
-    timing = time.perf_counter() - start
-
-    logger.info("Created thumbnail %s -> %s in %.1f seconds", filename, output, timing)
-    return [output]
+    return output

--- a/src/dlstbx/system_test/mimas.py
+++ b/src/dlstbx/system_test/mimas.py
@@ -67,13 +67,6 @@ class MimasService(CommonSystemTest):
             (
                 2,
                 {
-                    "recipes": ["generate-diffraction-preview"],
-                    "parameters": {"ispyb_dcid": 8257178},
-                },
-            ),
-            (
-                2,
-                {
                     "recipes": ["per-image-analysis-gridscan-i03-no-really"],
                     "parameters": {"ispyb_dcid": 8257178},
                 },


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/mx-analysis/issues/77 and partially fixes https://github.com/DiamondLightSource/mx-analysis/issues/76.

Stop the images service from generating any thumbnails as these have not been used by SynchWeb for a long time.

Make mimas only run the generate-diffraction-preview recipe for rotation data collections. The recipes still make separate calls to the images service as well, which currently duplicates the diffraction previews. The calls to the images service in the recipes will need to be removed to fix this.