### PR TITLE
include clustering html in multiplex logs and files

### DIFF
--- a/src/dlstbx/wrapper/xia2_multiplex.py
+++ b/src/dlstbx/wrapper/xia2_multiplex.py
@@ -180,6 +180,10 @@ class Xia2MultiplexWrapper(Wrapper):
                 if param not in ignore:
                     command.append(translation.get(param, param) + "=" + value[0])
 
+            # Output cluster html for easier display in SynchWeb
+
+            command.append("output.cluster_html=True")
+
         return command
 
     def run(self):


### PR DESCRIPTION
Change xia2.multiplex command line to output a specialised clustering-specific log file. Required for planned SynchWeb developments to improve visibility of clustering results. Testing shows it is uploaded and downloadable via logs and files with this code change. 