### PR TITLE
Update metal id to work with ccp4 9.0.015

### DIFF
--- a/src/dlstbx/wrapper/metal_id.py
+++ b/src/dlstbx/wrapper/metal_id.py
@@ -67,10 +67,10 @@ class MetalIdWrapper(Wrapper):
             auto_proc_program_id=self.recwrap.environment.get(
                 "ispyb_autoprocprogram_id"
             ),
-            rfree_start=dimple_log.getfloat("refmac5 restr", "ini_free_r"),
-            rfree_end=dimple_log.getfloat("refmac5 restr", "free_r"),
-            rwork_start=dimple_log.getfloat("refmac5 restr", "ini_overall_r"),
-            rwork_end=dimple_log.getfloat("refmac5 restr", "overall_r"),
+            rfree_start=dimple_log.getfloat("refmacat restr", "ini_free_r"),
+            rfree_end=dimple_log.getfloat("refmacat restr", "free_r"),
+            rwork_start=dimple_log.getfloat("refmacat restr", "ini_overall_r"),
+            rwork_end=dimple_log.getfloat("refmacat restr", "overall_r"),
         )
 
         blobs = []


### PR DESCRIPTION
Similar to #377, update the metal_id wrapper to look for refmacat section of logs instead of refmac5 for results. This is because dimple now uses refmacat instead of refmac5 for some refinement. 