### PR TITLE
Handle cbfs passed via ispyb_image in images service

### DIFF
--- a/src/dlstbx/services/images.py
+++ b/src/dlstbx/services/images.py
@@ -115,6 +115,9 @@ def diffraction(plugin: PluginInterface):
         filename = plugin.parameters("input")
         if ":" in filename:
             filename, imageset_index = filename.split(":")[0:2]
+            # cbf files can only contain one image
+            if filename.endswith(".cbf"):
+                imageset_index = 1
 
     if not filename or filename == "None":
         logger.debug("Skipping diffraction JPG generation: filename not specified")


### PR DESCRIPTION
We recently switched to using a single dedicated recipe for creating diffraction previews see (#378  #379). The new recipe, which passes in the diffraction images via the ispyb_image parameter, which has the format <file_path>:<first_image_number>:<last_image_number> doesn't work if the files are cbfs and the first image is not 1 as it sets the index to a value out of range for a cbf file. 

This patch forces the index to 1 for cbfs, because cbf files only contain one image and the ispyb_image parameter gives the file_path to the first image in the collection anyway. 