### PR TITLE
Support reprocessing legacy xchem

### DIFF
--- a/src/dlstbx/services/trigger_xchem.py
+++ b/src/dlstbx/services/trigger_xchem.py
@@ -251,6 +251,11 @@ class DLSTriggerXChem(CommonService):
         bulk_array = parameters.bulk_array
 
         protein_info = get_protein_for_dcid(parameters.dcid, session)
+        if protein_info is None:
+            self.log.info(
+                f"Exiting PanDDA2/Pipedream trigger: no Protein linked to dcid {dcid}"
+            )
+            return {"success": True}
         # protein_id = getattr(protein_info, "proteinId")
         proposal_id = getattr(protein_info, "proposalId")
         acronym = getattr(protein_info, "acronym")
@@ -888,6 +893,11 @@ class DLSTriggerXChem(CommonService):
         visit_number = visit.split("-")[1]
 
         protein_info = get_protein_for_dcid(parameters.dcid, session)
+        if protein_info is None:
+            self.log.info(
+                f"Exiting XChemCollate trigger: no Protein linked to dcid {dcid}"
+            )
+            return {"success": True}
         acronym = getattr(protein_info, "acronym")
         proposal_id = getattr(protein_info, "proposalId")
 

--- a/src/dlstbx/services/trigger_xchem.py
+++ b/src/dlstbx/services/trigger_xchem.py
@@ -290,7 +290,7 @@ class DLSTriggerXChem(CommonService):
         dtag, location, container_code = query.one()
         location = int(location)
 
-        # Check for crystal recollections
+        # Check for live crystal recollections
         latest_dcid = get_latest_dcid_for_dtag(dtag, session)
         if latest_dcid and latest_dcid != dcid:
             self.log.info(
@@ -740,10 +740,9 @@ class DLSTriggerXChem(CommonService):
                     src_model=pathlib.Path(parameters.use_existing_modeldir),
                     dst_model=model_dir,
                     visit_dir=xchem_visit_dir,
-                    overwrite=bool(overwrite),
                     logger=self.log,
                 )
-            except (FileNotFoundError, PermissionError) as e:
+            except Exception as e:
                 self.log.error(f"Exiting hitidentification trigger: {e}")
                 return {"success": True}
 
@@ -789,7 +788,9 @@ class DLSTriggerXChem(CommonService):
             )
             self.upsert_proc(rw, dcid, "PanDDA2-array", recipe_parameters)
             if pipedream:
-                self.log.info(f"Launching Pipedream for dtag {dtag}")
+                self.log.info(
+                    f"Launching Pipedream array job over {dataset_count} datasets"
+                )
                 self.upsert_proc(rw, dcid, "Pipedream-array", recipe_parameters)
             return {"success": True}
 

--- a/src/dlstbx/services/trigger_xchem.py
+++ b/src/dlstbx/services/trigger_xchem.py
@@ -639,16 +639,22 @@ class DLSTriggerXChem(CommonService):
 
         self.log.info(f"Creating directory {dataset_dir}")
 
-        if not overwrite:
-            try:
-                compound_dir.mkdir(parents=True, exist_ok=False)
-            except FileExistsError:
-                self.log.info(
-                    f"Exiting model_building trigger: {dataset_dir} already exists"
-                )
-                return {"success": True}
-        else:
-            compound_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            if not overwrite:
+                try:
+                    compound_dir.mkdir(parents=True, exist_ok=False)
+                except FileExistsError:
+                    self.log.info(
+                        f"Exiting model_building trigger: {dataset_dir} already exists"
+                    )
+                    return {"success": True}
+            else:
+                compound_dir.mkdir(parents=True, exist_ok=True)
+        except PermissionError as e:
+            self.log.error(
+                f"Exiting model_building trigger: cannot create {compound_dir}: {e}. "
+            )
+            return {"success": True}
 
         # Copy the dimple files of the selected dataset
         shutil.copy(pdb, str(dataset_dir / "dimple.pdb"))

--- a/src/dlstbx/services/trigger_xchem.py
+++ b/src/dlstbx/services/trigger_xchem.py
@@ -261,7 +261,7 @@ class DLSTriggerXChem(CommonService):
         acronym = getattr(protein_info, "acronym")
 
         # TEMPORARY PROPOSAL FILTER
-        ALLOWED_PROPOSALS = ["lb42888", "sw44043", "sw44107", "lb36049", "lb43133"]
+        ALLOWED_PROPOSALS = ["lb42888", "sw44043", "sw44107", "lb36049", "lb43133", "lb42944"]
         PROPOSAL_ALIASES = {"mx41448": "lb42888"}
 
         query = (session.query(Proposal)).filter(Proposal.proposalId == proposal_id)
@@ -857,7 +857,7 @@ class DLSTriggerXChem(CommonService):
         proposal of the triggering dcid's visit, then gates on those jobs:
         aborts if any PanDDA2/Pipedream/xia2 program newer than program_id has
         started, and checkpoints with exponential backoff while any of them are still
-        running. Once processing has settled, firesa single XChemCollate job keyed
+        running. Once processing has settled, fires a single XChemCollate job keyed
         on the highest dcid.
 
         Recipe parameters (ispyb placeholders shown as "{}"):

--- a/src/dlstbx/services/trigger_xchem.py
+++ b/src/dlstbx/services/trigger_xchem.py
@@ -44,6 +44,7 @@ from dlstbx.crud import (
 from dlstbx.util import ChainMapWithReplacement
 from dlstbx.util.prometheus_metrics import BasePrometheusMetrics, NoMetrics
 from dlstbx.util.soakdb import find_xchem_visit_dir
+from dlstbx.util.stage_reprocess import stage_legacy_model_building
 
 
 class PrometheusMetrics(BasePrometheusMetrics):
@@ -81,6 +82,7 @@ class HitIndentificationParameters(pydantic.BaseModel):
     pipedream: Optional[bool] = True
     overwrite: Optional[bool] = False
     bulk_array: Optional[bool] = False
+    use_existing_modeldir: Optional[str] = None
 
 
 class CollateParameters(pydantic.BaseModel):
@@ -696,6 +698,9 @@ class DLSTriggerXChem(CommonService):
 
         bulk_array=True: iterate model_dir directly, write the dataset list to
         .bulk_array.json, and fire one array job over dtags in model_building.
+
+        use_existing_modeldir=<legacy model_building path>: before enumerating,
+        copy the complete datasets from that legacy model_building dir
         """
         dcid = parameters.dcid
         scaling_id = parameters.scaling_id[0]
@@ -709,6 +714,20 @@ class DLSTriggerXChem(CommonService):
         processing_dir = xchem_visit_dir / "processing"
         model_dir = processing_dir / "auto" / "analysis" / "model_building"
         db_master = processing_dir / "database" / "soakDBDataFile.sqlite"
+
+        # Optionally stage a legacy model_building dir
+        if parameters.use_existing_modeldir:
+            try:
+                stage_legacy_model_building(
+                    src_model=pathlib.Path(parameters.use_existing_modeldir),
+                    dst_model=model_dir,
+                    visit_dir=xchem_visit_dir,
+                    overwrite=bool(overwrite),
+                    logger=self.log,
+                )
+            except (FileNotFoundError, PermissionError) as e:
+                self.log.error(f"Exiting hitidentification trigger: {e}")
+                return {"success": True}
 
         # Resolve dtag for the current dcid
         query = (
@@ -749,9 +768,7 @@ class DLSTriggerXChem(CommonService):
             )
             self.upsert_proc(rw, dcid, "PanDDA2-array", recipe_parameters)
             if pipedream:
-                self.log.info(
-                    f"Launching Pipedream array job over {dataset_count} datasets"
-                )
+                self.log.info(f"Launching Pipedream for dtag {dtag}")
                 self.upsert_proc(rw, dcid, "Pipedream-array", recipe_parameters)
             return {"success": True}
 

--- a/src/dlstbx/services/trigger_xchem.py
+++ b/src/dlstbx/services/trigger_xchem.py
@@ -294,7 +294,7 @@ class DLSTriggerXChem(CommonService):
         latest_dcid = get_latest_dcid_for_dtag(dtag, session)
         if latest_dcid and latest_dcid != dcid:
             self.log.info(
-                f"Exiting PanDDA2/Pipedream trigger: dcid {dcid} is not the latest for dtag {dtag}; Recollection underway?"
+                f"Exiting PanDDA2/Pipedream trigger: dcid {dcid} is not the latest for dtag {dtag}, recollection underway"
             )
             return {"success": True}
 
@@ -335,7 +335,7 @@ class DLSTriggerXChem(CommonService):
             "autoPROC",
             "autoPROC+STARANISO",
             "xia2.multiplex",
-        ]  # will consider dimple output from these jobs to take forward
+        ]  # consider dimple output from these jobs to take forward
 
         query = (
             session.query(AutoProcProgram.processingPrograms)
@@ -355,7 +355,8 @@ class DLSTriggerXChem(CommonService):
             )
             return {"success": True}
 
-        # If other dimple/PanDDA2 job is running, quit, dimple will trigger PanDDA2 even if it fails
+        # If another dimple/PanDDA2 job is running then quit,
+        # dimple set to trigger PanDDA2 even if it fails
         min_start_time = datetime.now() - timedelta(hours=6)
 
         query = (
@@ -444,8 +445,8 @@ class DLSTriggerXChem(CommonService):
 
                 return {"success": True}
 
-        # Select the 'best' dataset to take forward based on criteria,
-        # default is I/sigI*completeness*#unique reflections
+        # Select the 'best' dataset to take forward based on some criteria,
+        # default is I/sigI * completeness * #unique reflections
         query = (
             (
                 session.query(
@@ -487,7 +488,7 @@ class DLSTriggerXChem(CommonService):
                 df = df_filteredbysg
                 n_success_upstream = len(df)
                 self.log.info(
-                    f"There are {n_success_upstream} successful upstream jobs (excl fast-dp) in the user-defined spacegroup {user_sg} \
+                    f"There are {n_success_upstream} successful upstream jobs (excluding fast-dp) in the user-defined spacegroup {user_sg} \
                     selecting the best one based on I/sigI*completeness * #unique reflections, from the most recent processing batch"
                 )
 
@@ -501,7 +502,7 @@ class DLSTriggerXChem(CommonService):
         df = df[["autoProcScalingId", "heuristic"]].copy()
         scaling_ids = df["autoProcScalingId"].tolist()
 
-        # find associated dimple jobs from scaling_ids, take most recent batch if reprocessing
+        # find associated dimple jobs from scaling_ids
         query = (
             (
                 session.query(
@@ -559,7 +560,7 @@ class DLSTriggerXChem(CommonService):
 
         if df3.empty:
             self.log.info(
-                f"Exiting PanDDA2/Pipedream trigger: Issue selecting dataset to take forward for dcid {dcid}"
+                f"Exiting PanDDA2/Pipedream trigger: issue selecting dataset to take forward for dcid {dcid}"
             )
             return {"success": True}
 
@@ -586,7 +587,7 @@ class DLSTriggerXChem(CommonService):
 
         self.log.debug("PanDDA2/Pipedream trigger: Starting")
 
-        # 2. Read XChem SQLite database for ligand info
+        # 2. Read XChem SQLite database for ligand information
 
         db_master = processing_dir / "database" / "soakDBDataFile.sqlite"
 
@@ -624,7 +625,7 @@ class DLSTriggerXChem(CommonService):
             return {"success": True}
 
         # Apo / ground-state crystals have no CompoundSMILES: they are still
-        # put in model_building (below) so PanDDA2 can use them, but get no
+        # put in model_building directory so PanDDA2 can use them, but get no
         # .smiles file and no ligand-restraints job.
         has_ligand = bool(CompoundSMILES) and str(
             CompoundSMILES
@@ -705,11 +706,10 @@ class DLSTriggerXChem(CommonService):
         transaction: int,
         **kwargs,
     ):
-        """Launch PanDDA2 / Pipedream once restraints for this dcid are ready.
+        """Launches PanDDA2 / Pipedream hit identification pipelines for XChem.
 
         Records the current dcid and its dtag in model_dir/.batch_dcids.json as a
-        {dcid: dtag} map, so dtags can be read back at threshold without
-        re-querying ispyb. Pipedream fires for the current dcid on every call.
+        {dcid: dtag} map. Pipedream fires for the current dcid on every call.
         PanDDA2 is gated by the count of recorded dcids vs. comparator_threshold:
         below threshold → skip; at threshold → fire one per-dcid PanDDA2 job for
         each recorded dcid; above threshold → single PanDDA2 for the current dtag.
@@ -717,7 +717,7 @@ class DLSTriggerXChem(CommonService):
         bulk_array=True: iterate model_dir directly, write the dataset list to
         .bulk_array.json, and fire one array job over dtags in model_building.
 
-        use_existing_modeldir=<legacy model_building path>: before enumerating,
+        use_existing_modeldir=<existing model_building path>: before enumerating,
         copy the complete datasets from that legacy model_building dir
         """
         dcid = parameters.dcid
@@ -733,7 +733,7 @@ class DLSTriggerXChem(CommonService):
         model_dir = processing_dir / "auto" / "analysis" / "model_building"
         db_master = processing_dir / "database" / "soakDBDataFile.sqlite"
 
-        # Optionally stage a legacy model_building dir
+        # Optionally stage an existing model_building directory to use
         if parameters.use_existing_modeldir:
             try:
                 stage_existing_modeldir(
@@ -789,13 +789,12 @@ class DLSTriggerXChem(CommonService):
             self.upsert_proc(rw, dcid, "PanDDA2-array", recipe_parameters)
             if pipedream:
                 self.log.info(
-                    f"Launching Pipedream array job over {dataset_count} datasets"
+                    f"bulk_array=True, launching Pipedream array job over {dataset_count} datasets"
                 )
                 self.upsert_proc(rw, dcid, "Pipedream-array", recipe_parameters)
             return {"success": True}
 
-        # Record this dcid and its dtag in the hidden gating json, so the dtag
-        # can be read back at threshold without re-querying ispyb.
+        # Record this dcid and its dtag in the hidden gating json for PanDDA2
         dcids_file = model_dir / ".batch_dcids.json"
         if dcids_file.exists():
             with open(dcids_file, "r") as f:
@@ -810,6 +809,7 @@ class DLSTriggerXChem(CommonService):
         dataset_count = len(recorded_dcids)
         self.log.info(f"Recorded waiting dcid count is: {dataset_count}")
 
+        # Job launch logic
         if pipedream:
             self.log.info(f"Launching Pipedream for dtag {dtag}")
             self.upsert_proc(rw, dcid, "Pipedream", recipe_parameters)
@@ -856,10 +856,9 @@ class DLSTriggerXChem(CommonService):
         Gathers every dcid for this target (matched by Protein acronym) under the
         proposal of the triggering dcid's visit, then gates on those jobs:
         aborts if any PanDDA2/Pipedream/xia2 program newer than program_id has
-        started (a fresh batch is underway), and checkpoints with exponential
-        backoff while any of them are still running. Once processing has settled
-        and no other XChemCollate job is already in flight for the target, fires
-        a single XChemCollate job keyed on the highest dcid.
+        started, and checkpoints with exponential backoff while any of them are still
+        running. Once processing has settled, firesa single XChemCollate job keyed
+        on the highest dcid.
 
         Recipe parameters (ispyb placeholders shown as "{}"):
         - target: set this to "xchem_collate"
@@ -921,7 +920,7 @@ class DLSTriggerXChem(CommonService):
             .all()
         ]
 
-        # trigger on the final PanDDA/Pipedream program_id from the current
+        # Trigger on the final PanDDA/Pipedream program_id from the current
         # processing batch
         query = (
             (
@@ -945,7 +944,7 @@ class DLSTriggerXChem(CommonService):
             )
             return {"success": True}
 
-        # has processing finished? checkpoint if not
+        # Has processing finished? checkpoint if not
         min_start_time = datetime.now() - timedelta(hours=8)
         query = (
             (

--- a/src/dlstbx/services/trigger_xchem.py
+++ b/src/dlstbx/services/trigger_xchem.py
@@ -44,7 +44,7 @@ from dlstbx.crud import (
 from dlstbx.util import ChainMapWithReplacement
 from dlstbx.util.prometheus_metrics import BasePrometheusMetrics, NoMetrics
 from dlstbx.util.soakdb import find_xchem_visit_dir
-from dlstbx.util.stage_reprocess import stage_legacy_model_building
+from dlstbx.util.stage_reprocess import stage_existing_modeldir
 
 
 class PrometheusMetrics(BasePrometheusMetrics):
@@ -736,7 +736,7 @@ class DLSTriggerXChem(CommonService):
         # Optionally stage a legacy model_building dir
         if parameters.use_existing_modeldir:
             try:
-                stage_legacy_model_building(
+                stage_existing_modeldir(
                     src_model=pathlib.Path(parameters.use_existing_modeldir),
                     dst_model=model_dir,
                     visit_dir=xchem_visit_dir,
@@ -795,8 +795,7 @@ class DLSTriggerXChem(CommonService):
             return {"success": True}
 
         # Record this dcid and its dtag in the hidden gating json, so the dtag
-        # can be read back at threshold without re-querying ispyb. JSON keys are
-        # strings, so dcids round-trip as str.
+        # can be read back at threshold without re-querying ispyb.
         dcids_file = model_dir / ".batch_dcids.json"
         if dcids_file.exists():
             with open(dcids_file, "r") as f:

--- a/src/dlstbx/services/trigger_xchem.py
+++ b/src/dlstbx/services/trigger_xchem.py
@@ -235,8 +235,7 @@ class DLSTriggerXChem(CommonService):
         dimple jobs to finish, then selects the 'best' dataset by
         I/sigI * completeness * #unique-reflections, preferring those cases
         processed in the user-defined spacegroup and the most recent processing
-        batch. Reads the soakDB for ligand info, skipping DMSO solvent screens
-        and crystals with no CompoundSMILES.
+        batch. Reads the soakDB for ligand info, skipping DMSO solvent screens.
 
         Copies the chosen dimple files into the shared model_building directory,
         writes the ligand .smiles file, and fires a single ligand-restraints job
@@ -618,16 +617,18 @@ class DLSTriggerXChem(CommonService):
                 f"Exiting PanDDA2/Pipedream trigger: {dtag} is DMSO solvent screen, skipping..."
             )
             return {"success": True}
-        elif not CompoundSMILES or str(CompoundSMILES).strip().lower() in [
+
+        # Apo / ground-state crystals have no CompoundSMILES: they are still
+        # put in model_building (below) so PanDDA2 can use them, but get no
+        # .smiles file and no ligand-restraints job.
+        has_ligand = bool(CompoundSMILES) and str(
+            CompoundSMILES
+        ).strip().lower() not in (
             "none",
             "null",
             "nan",
             "",
-        ]:
-            self.log.info(
-                f"Exiting PanDDA2/Pipedream trigger: {dtag} has no corresponding CompoundSMILES, skipping..."
-            )
-            return {"success": True}
+        )
 
         # 3. Create dataset directory structure (single shared model_building dir)
         auto_dir = processing_dir / "auto"
@@ -653,6 +654,12 @@ class DLSTriggerXChem(CommonService):
         shutil.copy(pdb, str(dataset_dir / "dimple.pdb"))
         shutil.copy(mtz, str(dataset_dir / "dimple.mtz"))
         shutil.copy(upstream_mtz, str(dataset_dir / f"{dtag}.free.mtz"))
+
+        if not has_ligand:
+            self.log.info(
+                f"{dtag} has no CompoundSMILES; moved dimple files in model_building "
+            )
+            return {"success": True}
 
         with open(compound_dir / f"{CompoundCode}.smiles", "w") as smi_file:
             smi_file.write(CompoundSMILES)
@@ -756,8 +763,11 @@ class DLSTriggerXChem(CommonService):
         }
 
         if bulk_array:
+            # Only run on datasets that have a ligand
             dataset_list = sorted(
-                [p.parts[-1] for p in model_dir.iterdir() if p.is_dir()]
+                p.parts[-1]
+                for p in model_dir.iterdir()
+                if p.is_dir() and list((p / "compound").glob("*.smiles"))
             )
             dataset_count = len(dataset_list)
             recipe_parameters["n_datasets"] = dataset_count

--- a/src/dlstbx/services/trigger_xchem.py
+++ b/src/dlstbx/services/trigger_xchem.py
@@ -256,7 +256,7 @@ class DLSTriggerXChem(CommonService):
         acronym = getattr(protein_info, "acronym")
 
         # TEMPORARY PROPOSAL FILTER
-        ALLOWED_PROPOSALS = ["lb42888", "sw44043", "sw44107", "lb36049", "sw44082"]
+        ALLOWED_PROPOSALS = ["lb42888", "sw44043", "sw44107", "lb36049", "lb43133"]
         PROPOSAL_ALIASES = {"mx41448": "lb42888"}
 
         query = (session.query(Proposal)).filter(Proposal.proposalId == proposal_id)

--- a/src/dlstbx/util/pandda.py
+++ b/src/dlstbx/util/pandda.py
@@ -192,8 +192,7 @@ def merge_build(receptor, ligand, contact_chain):
 def get_pandda_settings(yaml_file):
     """Turn a visit's .user.yaml into PanDDA2 ``--key=value`` args.
 
-    A visit need not have a .user.yaml, and one that exists may be empty. Both
-    mean "no overrides", which leaves PanDDA2 on its own defaults.
+    A visit need not have a .user.yaml, and one that exists may be empty.
     """
     try:
         with open(yaml_file, "r") as file:

--- a/src/dlstbx/util/pandda.py
+++ b/src/dlstbx/util/pandda.py
@@ -190,8 +190,16 @@ def merge_build(receptor, ligand, contact_chain):
 
 
 def get_pandda_settings(yaml_file):
-    with open(yaml_file, "r") as file:
-        expt_yaml = yaml.load(file, Loader=yaml.SafeLoader)
+    """Turn a visit's .user.yaml into PanDDA2 ``--key=value`` args.
+
+    A visit need not have a .user.yaml, and one that exists may be empty. Both
+    mean "no overrides", which leaves PanDDA2 on its own defaults.
+    """
+    try:
+        with open(yaml_file, "r") as file:
+            expt_yaml = yaml.load(file, Loader=yaml.SafeLoader) or {}
+    except FileNotFoundError:
+        return ""
     settings = expt_yaml.get("autoprocessing", {}).get("pandda", {})
     if settings:
         args_string = " ".join(f"--{k}={v}" for k, v in settings.items())

--- a/src/dlstbx/util/soakdb.py
+++ b/src/dlstbx/util/soakdb.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import yaml
 
 
-def _soakdb_path(visit_dir: Path) -> Path:
+def soakdb_path(visit_dir: Path) -> Path:
     return visit_dir / "processing/database" / "soakDBDataFile.sqlite"
 
 
@@ -71,7 +71,7 @@ def find_xchem_visit_dir(
 
     # several visits share this target: disambiguate by the crystal's location
     for visit_dir in candidates:
-        db_path = _soakdb_path(visit_dir)
+        db_path = soakdb_path(visit_dir)
         if not db_path.is_file():
             log.info(f"No .sqlite database at {db_path} for dtag {dtag}, skipping")
             continue
@@ -91,7 +91,7 @@ def find_xchem_visit_dir(
     for subdir in xchem_dir.iterdir():
         if (subdir / ".user.yaml").exists():
             continue
-        db_path = _soakdb_path(subdir)
+        db_path = soakdb_path(subdir)
         if not db_path.is_file():
             continue
         try:

--- a/src/dlstbx/util/stage_reprocess.py
+++ b/src/dlstbx/util/stage_reprocess.py
@@ -1,8 +1,7 @@
-"""Stage a legacy XChemExplorer ``model_building`` tree for autoprocessing.
+"""Stage a legacy XChem ``model_building`` tree for autoprocessing.
 
-Copies the files the PanDDA2 / Pipedream pipeline needs from the **legacy**
-XChemExplorer model_building tree into the **autoprocessing** tree the new
-pipeline reads from.
+Copies the files the PanDDA2 / Pipedream pipeline needs from an existing
+XChem model_building tree into the autoprocessing tree.
 
     <visit>/processing/analysis/model_building/<dtag>/
         -> <visit>/processing/auto/analysis/model_building/<dtag>/
@@ -10,9 +9,9 @@ pipeline reads from.
 Ligand datasets are copied only when ``complete`` (a single
 ``compound/<code>.smiles`` with a matching ``<code>.cif``), so every staged dir
 holding a ``.smiles`` is runnable by a ``bulk_array`` job. Apo / ground-state
-datasets are copied without ligand files, mirroring what ``trigger_xchem`` does
-for live apo collections. DMSO/solvent soaks are excluded, as they are in the
-trigger. Everything not copied is recorded in ``staging_report.json``.
+datasets are copied without ligand files, mirroring ``trigger_xchem`` behaviour
+for live apo collections. DMSO/solvent soaks are excluded. Everything not copied
+is recorded in output ``staging_report.json``.
 """
 
 from __future__ import annotations
@@ -27,33 +26,19 @@ from pathlib import Path
 from dlstbx.util.soakdb import soakdb_path
 
 # Apo / ground-state crystals carry no ligand. They are staged with core files
-# only, because PanDDA2 uses them as ground-state comparators and trigger_xchem
-# stages live apo collections the same way. With no `.smiles` in the staged dir
-# the bulk_array dataset list passes over them, so they get no PanDDA2 /
-# Pipedream task of their own.
+# only, because PanDDA2 uses them as ground-state comparators.
 APO_STATUSES = frozenset({"no_compound", "no_smiles"})
 
-# `no_cif` and `multi_smiles` are deliberately left unstaged rather than staged
-# as apo: any dir holding a `.smiles` is picked up as a bulk_array task, which
-# would then run ligand fitting with no usable restraints. `no_cif` datasets are
-# recoverable — regenerate the grade2 restraints, then re-stage.
+# `no_cif` and `multi_smiles` are deliberately left unstaged.
 STAGED_STATUSES = APO_STATUSES | {"complete"}
 
-# DMSO / solvent soaks are screens, not real ligand experiments. Visits tag them
-# inconsistently: LibraryName is `DMSO` or `Solvent`, or is unset and only the
-# SMILES gives it away. Match all three so none slips through.
+# DMSO / solvent soaks are screens, not real ligand experiments.
 _DMSO_SMILES = "CS(=O)C"
 _SOLVENT_LIBRARIES = frozenset({"DMSO", "SOLVENT"})
 
 
 def dimple_source(ds_dir: Path, ext: str) -> Path | None:
-    """Locate a legacy dimple output, preferring the top-level symlink.
-
-    XChemExplorer usually leaves ``dimple.<ext>`` at the top of the dataset dir
-    pointing at the real dimple run, but not always, so fall back to the run
-    itself. ``.exists()`` follows symlinks, so a dangling legacy symlink falls
-    through to the fallback rather than being staged as a broken file.
-    """
+    """Locate a legacy dimple output, preferring the top-level symlink."""
     top = ds_dir / f"dimple.{ext}"
     if top.exists():
         return top
@@ -62,16 +47,7 @@ def dimple_source(ds_dir: Path, ext: str) -> Path | None:
 
 
 def solvent_soak_dtags(db_path: Path, logger: logging.Logger) -> set[str]:
-    """Return the dtags soakDB marks as DMSO/solvent soaks.
-
-    Takes the database path rather than the visit dir, so an analysis caller can
-    point this at a working copy of the soakDB while staging reads the master.
-
-    A crystal can hold several ``mainTable`` rows (recollections); the newest
-    (max ``ID``) row wins, so a re-soak is judged on its latest state. Returns
-    an empty set if there is no soakDB, leaving every dataset to be judged on
-    its disk contents alone.
-    """
+    """Return the dtags soakDB marks as DMSO/solvent soaks."""
     if not db_path.is_file():
         logger.warning(f"No soakDB at {db_path}; continuing without a solvent filter")
         return set()
@@ -100,12 +76,7 @@ def build_stage_plan(ds_dir: Path) -> tuple[dict[Path, str] | None, str]:
     Core files (dimple pdb + mtz, ``<dtag>.free.mtz``) are required: without
     them there is nothing for the pipeline to process, so the dataset is
     unstageable -> ``(None, "missing <file>")``. When present, ligand files are
-    added and a status classifies how complete the dataset is. ``.exists()``
-    follows symlinks, so a legacy symlink whose target is gone is correctly
-    treated as missing.
-
-    ``CompoundCode`` is taken from the ``.smiles`` stem, exactly as the wrappers
-    derive it (``pandda_xchem.py``, ``pipedream_xchem.py``).
+    added and a status classifies how complete the dataset is.
 
     Returns ``(plan, status)`` where ``plan`` maps a source ``Path`` to its dest
     path relative to the dataset dir; ``status`` is one of: ``complete``,
@@ -163,8 +134,8 @@ def stage_legacy_model_building(
     """Copy the runnable legacy datasets from ``src_model`` into ``dst_model``.
 
     Ligand datasets are copied only when they hold a single
-    ``compound/<code>.smiles`` with a matching ``<code>.cif``, so every staged
-    dir carrying a ``.smiles`` is runnable by a downstream ``bulk_array`` job.
+    ``compound/<code>.smiles`` with a matching ``<code>.cif``.
+
     Apo datasets are copied without ligand files, and DMSO/solvent soaks are
     skipped entirely — both matching what ``trigger_xchem`` does live. Copies
     follow symlinks, so legacy symlinked ``dimple`` files become real files
@@ -173,9 +144,6 @@ def stage_legacy_model_building(
 
     Writes a ``staging_report.json`` next to ``dst_model`` so incomplete /
     unstageable datasets can be triaged later.
-
-    Raises ``FileNotFoundError`` if ``src_model`` is missing and
-    ``PermissionError`` if ``dst_model`` is not writable by the caller.
     """
     if logger is None:
         logger = logging.getLogger(__name__)

--- a/src/dlstbx/util/stage_reprocess.py
+++ b/src/dlstbx/util/stage_reprocess.py
@@ -151,7 +151,6 @@ def stage_existing_modeldir(
     if not src_model.is_dir():
         raise FileNotFoundError(f"source model_building not found: {src_model}")
 
-    # Writability guard: walk up to the first existing ancestor of dst_model.
     parent = dst_model
     while not parent.exists():
         parent = parent.parent

--- a/src/dlstbx/util/stage_reprocess.py
+++ b/src/dlstbx/util/stage_reprocess.py
@@ -1,0 +1,182 @@
+"""Stage a legacy XChemExplorer ``model_building`` tree for autoprocessing.
+
+Copies the files the PanDDA2 / Pipedream pipeline needs from the **legacy**
+XChemExplorer model_building tree into the **autoprocessing** tree the new
+pipeline reads from.
+
+    <visit>/processing/analysis/model_building/<dtag>/
+        -> <visit>/processing/auto/analysis/model_building/<dtag>/
+
+Only ``complete`` datasets (a single ``compound/<code>.smiles`` with a matching
+``<code>.cif``) are copied, so every staged dir is runnable by a ``bulk_array``
+job. Incomplete and unstageable datasets are recorded in ``staging_report.json``
+but not copied.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import textwrap
+from pathlib import Path
+
+# get_pandda_settings() reads autoprocessing.pandda and turns each key/value
+# into a --key=value PanDDA2 arg; an empty mapping yields defaults.
+_USER_YAML = textwrap.dedent(
+    """\
+    # Minimal .user.yaml written by the reprocessing staging step.
+    autoprocessing:
+      pandda: {}
+    """
+)
+
+
+def build_stage_plan(ds_dir: Path) -> tuple[dict[Path, str] | None, str]:
+    """Build the copy plan for one legacy XChemExplorer dataset dir.
+
+    Core files (``dimple.pdb``, ``dimple.mtz``, ``<dtag>.free.mtz``) are
+    required: without them there is nothing for the pipeline to process, so the
+    dataset is unstageable -> ``(None, "missing <file>")``. When present, ligand
+    files are added and a status classifies how complete the dataset is.
+    ``.exists()`` follows symlinks, so a legacy symlink whose target is gone is
+    correctly treated as missing.
+
+    ``CompoundCode`` is taken from the ``.smiles`` stem, exactly as the wrappers
+    derive it (``pandda_xchem.py``, ``pipedream_xchem.py``).
+
+    Returns ``(plan, status)`` where ``plan`` maps a source ``Path`` to its dest
+    path relative to the dataset dir; ``status`` is one of: ``complete``,
+    ``no_cif``, ``no_smiles``, ``no_compound``, ``multi_smiles``.
+    """
+    dtag = ds_dir.name
+    dimple_pdb = ds_dir / "dimple.pdb"
+    dimple_mtz = ds_dir / "dimple.mtz"
+    free_mtz = ds_dir / f"{dtag}.free.mtz"
+    for f in (dimple_pdb, dimple_mtz, free_mtz):
+        if not f.exists():
+            return None, f"missing {f.name}"
+
+    plan = {
+        dimple_pdb: "dimple.pdb",
+        dimple_mtz: "dimple.mtz",
+        free_mtz: f"{dtag}.free.mtz",
+    }
+
+    compound = ds_dir / "compound"
+    if not compound.is_dir():
+        return plan, "no_compound"
+
+    smiles_files = sorted(compound.glob("*.smiles"))
+    if len(smiles_files) == 0:
+        return plan, "no_smiles"
+    if len(smiles_files) > 1:
+        return plan, "multi_smiles"  # ambiguous: don't copy ligand files
+    smiles = smiles_files[0]
+    cc = smiles.stem  # CompoundCode, as the wrappers derive it
+    plan[smiles] = f"compound/{smiles.name}"
+
+    cc_pdb = compound / f"{cc}.pdb"
+    if cc_pdb.exists():
+        plan[cc_pdb] = f"compound/{cc_pdb.name}"
+
+    cif = compound / f"{cc}.cif"
+    if cif.exists():
+        plan[cif] = f"compound/{cif.name}"
+        return plan, "complete"
+    return plan, "no_cif"
+
+
+def stage_legacy_model_building(
+    src_model: Path,
+    dst_model: Path,
+    *,
+    visit_dir: Path,
+    overwrite: bool = False,
+    logger: logging.Logger | None = None,
+) -> dict:
+    """Copy ``complete`` legacy datasets from ``src_model`` into ``dst_model``.
+
+    Only datasets with a single ``compound/<code>.smiles`` and a matching
+    ``<code>.cif`` are copied, so every staged dir is runnable by a downstream
+    ``bulk_array`` job. Copies follow symlinks, so legacy symlinked ``dimple``
+    files become real files under ``dst_model``. Datasets already present in
+    ``dst_model`` are left untouched unless ``overwrite`` is set.
+
+    Also ensures ``<visit_dir>/.user.yaml`` exists, because the PanDDA2
+    wrapper's ``get_pandda_settings()`` opens it unconditionally, and writes a
+    ``staging_report.json`` next to ``dst_model`` so incomplete / unstageable
+    datasets can be triaged later.
+
+    Raises ``FileNotFoundError`` if ``src_model`` is missing and
+    ``PermissionError`` if ``dst_model`` is not writable by the caller.
+    """
+    if logger is None:
+        logger = logging.getLogger(__name__)
+
+    if not src_model.is_dir():
+        raise FileNotFoundError(f"source model_building not found: {src_model}")
+
+    # Writability guard: walk up to the first existing ancestor of dst_model.
+    parent = dst_model
+    while not parent.exists():
+        parent = parent.parent
+    if not os.access(parent, os.W_OK):
+        raise PermissionError(
+            f"No write access to {parent}; run the trigger as a member of the "
+            "visit group (e.g. gda2)."
+        )
+
+    staged: dict[str, str] = {}  # dtag -> status, present in dst (copied or kept)
+    incomplete: dict[str, str] = {}  # dtag -> status, not copied (no usable cif)
+    unstageable: dict[str, str] = {}  # dtag -> reason, core files missing
+    skipped_existing: list[str] = []  # dtags already present, not overwritten
+
+    for ds in sorted(p for p in src_model.iterdir() if p.is_dir()):
+        dtag = ds.name
+        plan, status = build_stage_plan(ds)
+        if plan is None:
+            unstageable[dtag] = status
+            continue
+        if status != "complete":
+            incomplete[dtag] = status
+            continue
+
+        dst_dir = dst_model / dtag
+        if dst_dir.exists() and not overwrite:
+            skipped_existing.append(dtag)
+            staged[dtag] = status
+            continue
+
+        for src, rel in plan.items():
+            dst = dst_dir / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(src, dst)  # follows symlinks -> writes a real file
+        staged[dtag] = status
+
+    # The PanDDA2 wrapper opens <visit>/.user.yaml unconditionally.
+    user_yaml = visit_dir / ".user.yaml"
+    if not user_yaml.exists():
+        user_yaml.write_text(_USER_YAML)
+        logger.info(f"Wrote minimal {user_yaml}")
+
+    report = {
+        "src_model": str(src_model),
+        "dst_model": str(dst_model),
+        "staged": staged,
+        "incomplete": incomplete,
+        "unstageable": unstageable,
+        "skipped_existing": skipped_existing,
+    }
+    report_path = dst_model.parent / "staging_report.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(json.dumps(report, indent=2))
+
+    logger.info(
+        f"Staged {len(staged)} complete dataset(s) "
+        f"({len(skipped_existing)} already present) from {src_model} to "
+        f"{dst_model}; skipped {len(incomplete)} incomplete and "
+        f"{len(unstageable)} unstageable. Report: {report_path}"
+    )
+    return report

--- a/src/dlstbx/util/stage_reprocess.py
+++ b/src/dlstbx/util/stage_reprocess.py
@@ -110,7 +110,7 @@ def build_stage_plan(ds_dir: Path) -> tuple[dict[Path, str] | None, str]:
     if len(smiles_files) > 1:
         return plan, "multi_smiles"  # ambiguous: don't copy ligand files
     smiles = smiles_files[0]
-    cc = smiles.stem  # CompoundCode, as the wrappers derive it
+    cc = smiles.stem  # CompoundCode
     plan[smiles] = f"compound/{smiles.name}"
 
     cc_pdb = compound / f"{cc}.pdb"
@@ -124,7 +124,7 @@ def build_stage_plan(ds_dir: Path) -> tuple[dict[Path, str] | None, str]:
     return plan, "no_cif"
 
 
-def stage_legacy_model_building(
+def stage_existing_modeldir(
     src_model: Path,
     dst_model: Path,
     *,

--- a/src/dlstbx/util/stage_reprocess.py
+++ b/src/dlstbx/util/stage_reprocess.py
@@ -7,10 +7,12 @@ pipeline reads from.
     <visit>/processing/analysis/model_building/<dtag>/
         -> <visit>/processing/auto/analysis/model_building/<dtag>/
 
-Only ``complete`` datasets (a single ``compound/<code>.smiles`` with a matching
-``<code>.cif``) are copied, so every staged dir is runnable by a ``bulk_array``
-job. Incomplete and unstageable datasets are recorded in ``staging_report.json``
-but not copied.
+Ligand datasets are copied only when ``complete`` (a single
+``compound/<code>.smiles`` with a matching ``<code>.cif``), so every staged dir
+holding a ``.smiles`` is runnable by a ``bulk_array`` job. Apo / ground-state
+datasets are copied without ligand files, mirroring what ``trigger_xchem`` does
+for live apo collections. DMSO/solvent soaks are excluded, as they are in the
+trigger. Everything not copied is recorded in ``staging_report.json``.
 """
 
 from __future__ import annotations
@@ -19,44 +21,107 @@ import json
 import logging
 import os
 import shutil
-import textwrap
+import sqlite3
 from pathlib import Path
 
-# get_pandda_settings() reads autoprocessing.pandda and turns each key/value
-# into a --key=value PanDDA2 arg; an empty mapping yields defaults.
-_USER_YAML = textwrap.dedent(
-    """\
-    # Minimal .user.yaml written by the reprocessing staging step.
-    autoprocessing:
-      pandda: {}
+from dlstbx.util.soakdb import soakdb_path
+
+# Apo / ground-state crystals carry no ligand. They are staged with core files
+# only, because PanDDA2 uses them as ground-state comparators and trigger_xchem
+# stages live apo collections the same way. With no `.smiles` in the staged dir
+# the bulk_array dataset list passes over them, so they get no PanDDA2 /
+# Pipedream task of their own.
+APO_STATUSES = frozenset({"no_compound", "no_smiles"})
+
+# `no_cif` and `multi_smiles` are deliberately left unstaged rather than staged
+# as apo: any dir holding a `.smiles` is picked up as a bulk_array task, which
+# would then run ligand fitting with no usable restraints. `no_cif` datasets are
+# recoverable — regenerate the grade2 restraints, then re-stage.
+STAGED_STATUSES = APO_STATUSES | {"complete"}
+
+# DMSO / solvent soaks are screens, not real ligand experiments. Visits tag them
+# inconsistently: LibraryName is `DMSO` or `Solvent`, or is unset and only the
+# SMILES gives it away. Match all three so none slips through.
+_DMSO_SMILES = "CS(=O)C"
+_SOLVENT_LIBRARIES = frozenset({"DMSO", "SOLVENT"})
+
+
+def dimple_source(ds_dir: Path, ext: str) -> Path | None:
+    """Locate a legacy dimple output, preferring the top-level symlink.
+
+    XChemExplorer usually leaves ``dimple.<ext>`` at the top of the dataset dir
+    pointing at the real dimple run, but not always, so fall back to the run
+    itself. ``.exists()`` follows symlinks, so a dangling legacy symlink falls
+    through to the fallback rather than being staged as a broken file.
     """
-)
+    top = ds_dir / f"dimple.{ext}"
+    if top.exists():
+        return top
+    final = ds_dir / "dimple" / "dimple" / f"final.{ext}"
+    return final if final.exists() else None
+
+
+def solvent_soak_dtags(db_path: Path, logger: logging.Logger) -> set[str]:
+    """Return the dtags soakDB marks as DMSO/solvent soaks.
+
+    Takes the database path rather than the visit dir, so an analysis caller can
+    point this at a working copy of the soakDB while staging reads the master.
+
+    A crystal can hold several ``mainTable`` rows (recollections); the newest
+    (max ``ID``) row wins, so a re-soak is judged on its latest state. Returns
+    an empty set if there is no soakDB, leaving every dataset to be judged on
+    its disk contents alone.
+    """
+    if not db_path.is_file():
+        logger.warning(f"No soakDB at {db_path}; continuing without a solvent filter")
+        return set()
+
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=10)
+    try:
+        rows = con.execute(
+            "SELECT CrystalName, LibraryName, CompoundSMILES FROM mainTable "
+            "WHERE CrystalName IS NOT NULL ORDER BY ID"
+        ).fetchall()
+    finally:
+        con.close()
+
+    latest = {dtag: (library, smiles) for dtag, library, smiles in rows}
+    return {
+        dtag
+        for dtag, (library, smiles) in latest.items()
+        if (library or "").strip().upper() in _SOLVENT_LIBRARIES
+        or (smiles or "").strip() == _DMSO_SMILES
+    }
 
 
 def build_stage_plan(ds_dir: Path) -> tuple[dict[Path, str] | None, str]:
     """Build the copy plan for one legacy XChemExplorer dataset dir.
 
-    Core files (``dimple.pdb``, ``dimple.mtz``, ``<dtag>.free.mtz``) are
-    required: without them there is nothing for the pipeline to process, so the
-    dataset is unstageable -> ``(None, "missing <file>")``. When present, ligand
-    files are added and a status classifies how complete the dataset is.
-    ``.exists()`` follows symlinks, so a legacy symlink whose target is gone is
-    correctly treated as missing.
+    Core files (dimple pdb + mtz, ``<dtag>.free.mtz``) are required: without
+    them there is nothing for the pipeline to process, so the dataset is
+    unstageable -> ``(None, "missing <file>")``. When present, ligand files are
+    added and a status classifies how complete the dataset is. ``.exists()``
+    follows symlinks, so a legacy symlink whose target is gone is correctly
+    treated as missing.
 
     ``CompoundCode`` is taken from the ``.smiles`` stem, exactly as the wrappers
     derive it (``pandda_xchem.py``, ``pipedream_xchem.py``).
 
     Returns ``(plan, status)`` where ``plan`` maps a source ``Path`` to its dest
     path relative to the dataset dir; ``status`` is one of: ``complete``,
-    ``no_cif``, ``no_smiles``, ``no_compound``, ``multi_smiles``.
+    ``no_cif``, ``no_smiles``, ``no_compound``, ``multi_smiles``. The dimple
+    files land under their canonical names whichever source they came from.
     """
     dtag = ds_dir.name
-    dimple_pdb = ds_dir / "dimple.pdb"
-    dimple_mtz = ds_dir / "dimple.mtz"
+    dimple_pdb = dimple_source(ds_dir, "pdb")
+    if dimple_pdb is None:
+        return None, "missing dimple.pdb"
+    dimple_mtz = dimple_source(ds_dir, "mtz")
+    if dimple_mtz is None:
+        return None, "missing dimple.mtz"
     free_mtz = ds_dir / f"{dtag}.free.mtz"
-    for f in (dimple_pdb, dimple_mtz, free_mtz):
-        if not f.exists():
-            return None, f"missing {f.name}"
+    if not free_mtz.exists():
+        return None, f"missing {free_mtz.name}"
 
     plan = {
         dimple_pdb: "dimple.pdb",
@@ -93,21 +158,21 @@ def stage_legacy_model_building(
     dst_model: Path,
     *,
     visit_dir: Path,
-    overwrite: bool = False,
     logger: logging.Logger | None = None,
 ) -> dict:
-    """Copy ``complete`` legacy datasets from ``src_model`` into ``dst_model``.
+    """Copy the runnable legacy datasets from ``src_model`` into ``dst_model``.
 
-    Only datasets with a single ``compound/<code>.smiles`` and a matching
-    ``<code>.cif`` are copied, so every staged dir is runnable by a downstream
-    ``bulk_array`` job. Copies follow symlinks, so legacy symlinked ``dimple``
-    files become real files under ``dst_model``. Datasets already present in
-    ``dst_model`` are left untouched unless ``overwrite`` is set.
+    Ligand datasets are copied only when they hold a single
+    ``compound/<code>.smiles`` with a matching ``<code>.cif``, so every staged
+    dir carrying a ``.smiles`` is runnable by a downstream ``bulk_array`` job.
+    Apo datasets are copied without ligand files, and DMSO/solvent soaks are
+    skipped entirely — both matching what ``trigger_xchem`` does live. Copies
+    follow symlinks, so legacy symlinked ``dimple`` files become real files
+    under ``dst_model``. Datasets already staged into ``dst_model`` are left
+    alone, so a re-run only fills in what is missing.
 
-    Also ensures ``<visit_dir>/.user.yaml`` exists, because the PanDDA2
-    wrapper's ``get_pandda_settings()`` opens it unconditionally, and writes a
-    ``staging_report.json`` next to ``dst_model`` so incomplete / unstageable
-    datasets can be triaged later.
+    Writes a ``staging_report.json`` next to ``dst_model`` so incomplete /
+    unstageable datasets can be triaged later.
 
     Raises ``FileNotFoundError`` if ``src_model`` is missing and
     ``PermissionError`` if ``dst_model`` is not writable by the caller.
@@ -128,23 +193,29 @@ def stage_legacy_model_building(
             "visit group (e.g. gda2)."
         )
 
+    solvent_soaks = solvent_soak_dtags(soakdb_path(visit_dir), logger)
+
     staged: dict[str, str] = {}  # dtag -> status, present in dst (copied or kept)
     incomplete: dict[str, str] = {}  # dtag -> status, not copied (no usable cif)
     unstageable: dict[str, str] = {}  # dtag -> reason, core files missing
+    dmso_excluded: list[str] = []  # dtags dropped as DMSO/solvent soaks
     skipped_existing: list[str] = []  # dtags already present, not overwritten
 
     for ds in sorted(p for p in src_model.iterdir() if p.is_dir()):
         dtag = ds.name
+        if dtag in solvent_soaks:
+            dmso_excluded.append(dtag)
+            continue
         plan, status = build_stage_plan(ds)
         if plan is None:
             unstageable[dtag] = status
             continue
-        if status != "complete":
+        if status not in STAGED_STATUSES:
             incomplete[dtag] = status
             continue
 
         dst_dir = dst_model / dtag
-        if dst_dir.exists() and not overwrite:
+        if dst_dir.exists():
             skipped_existing.append(dtag)
             staged[dtag] = status
             continue
@@ -155,28 +226,25 @@ def stage_legacy_model_building(
             shutil.copy(src, dst)  # follows symlinks -> writes a real file
         staged[dtag] = status
 
-    # The PanDDA2 wrapper opens <visit>/.user.yaml unconditionally.
-    user_yaml = visit_dir / ".user.yaml"
-    if not user_yaml.exists():
-        user_yaml.write_text(_USER_YAML)
-        logger.info(f"Wrote minimal {user_yaml}")
-
     report = {
         "src_model": str(src_model),
         "dst_model": str(dst_model),
         "staged": staged,
         "incomplete": incomplete,
         "unstageable": unstageable,
+        "dmso_excluded": dmso_excluded,
         "skipped_existing": skipped_existing,
     }
     report_path = dst_model.parent / "staging_report.json"
     report_path.parent.mkdir(parents=True, exist_ok=True)
     report_path.write_text(json.dumps(report, indent=2))
 
+    n_apo = sum(1 for status in staged.values() if status in APO_STATUSES)
     logger.info(
-        f"Staged {len(staged)} complete dataset(s) "
+        f"Staged {len(staged)} dataset(s), {n_apo} of them apo "
         f"({len(skipped_existing)} already present) from {src_model} to "
-        f"{dst_model}; skipped {len(incomplete)} incomplete and "
-        f"{len(unstageable)} unstageable. Report: {report_path}"
+        f"{dst_model}; skipped {len(incomplete)} incomplete, "
+        f"{len(unstageable)} unstageable and {len(dmso_excluded)} DMSO/solvent. "
+        f"Report: {report_path}"
     )
     return report

--- a/src/dlstbx/util/xchem_collate_helpers.py
+++ b/src/dlstbx/util/xchem_collate_helpers.py
@@ -345,7 +345,7 @@ def update_xchem_database(
             logger.error(f"Multiple .cif files in {compound_dir}")
 
         CompoundCode = cif_files[0].stem
-        db_timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S.%f")[:-4]
+        db_timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
 
         pipedream_model, rscc = find_pipedream_model(
             pipedream_dir, dtag, rscc_thresh=0.7

--- a/src/dlstbx/util/xchem_collate_helpers.py
+++ b/src/dlstbx/util/xchem_collate_helpers.py
@@ -232,12 +232,21 @@ def export_pipedream_files(
     )
 
 
-def symlink_score_buckets(panddas_dir, pandda_dir, updatable, logger):
-    """Build score-bucketed, symlinked copies of the PanDDA processed_datasets
-    dir so models can be browsed by ligand score. Only datasets still in
-    `updatable` (not yet processed by the autopipeline) are bucketed.
+def symlink_score_buckets(
+    panddas_dir, pandda_dir, logger, buckets=(0, 0.4, 0.6, 0.8, 0.9, 1)
+):
+    """Build score-bucketed, symlinked views of the PanDDA processed_datasets
+    dir so models can be browsed by event score.
 
-    Scores come from the per-dataset best_score.txt written by pandda_xchem."""
+    Scores are the `z_mean` column of pandda_analyse_events.csv, which is the
+    events.yaml `Score`. (`z_peak` is the nested Build/Score, a different
+    quantity -- don't score on it.)
+
+    Bucketing is per EVENT, not per dataset, so a dataset with events in more
+    than one band is browsable under each. Every run rebuilds the view from the
+    whole events csv, which is the complete picture of what PanDDA has
+    processed, so no dataset filter or cross-run accumulation is needed:
+    symlinks a re-analysis has moved to another band are pruned."""
 
     processed_dataset_dir = panddas_dir / "processed_datasets"
     events_csv = panddas_dir / "analyses" / "pandda_analyse_events.csv"
@@ -247,48 +256,67 @@ def symlink_score_buckets(panddas_dir, pandda_dir, updatable, logger):
         logger.info(f"No {events_csv}, skipping score bucketing")
         return
 
-    # scores[dtag] = best ligand score
-    scores = {}
-    for dataset in processed_dataset_dir.iterdir():
-        if dataset.name not in updatable:
-            continue
-        score_file = dataset / "best_score.txt"
-        if score_file.exists():
-            scores[dataset.name] = float(score_file.read_text().strip())
-
-    sorted_scores = sorted(scores.items(), key=lambda x: x[1], reverse=True)
-
     df = pd.read_csv(events_csv, index_col=0)
-    buckets = [0.6, 0.8, 0.9, 1]  # boundaries
-    for j in range(len(buckets) - 1):
-        bucket_dtags = [
-            dtag
-            for dtag, score in sorted_scores
-            if buckets[j] < score <= buckets[j + 1]
-        ]
+
+    for lo, hi in zip(buckets, buckets[1:]):
+        # `> lo` / `<= hi` keeps the bands contiguous across (0, 1]: an event
+        # landing exactly on a boundary goes to the lower band, not to neither.
+        bucket_events = df[(df["z_mean"] > lo) & (df["z_mean"] <= hi)].copy()
+        bucket_dtags = set(bucket_events["dtag"])
         logger.info(
-            f"Datasets scored {buckets[j]}-{buckets[j + 1]}: {len(bucket_dtags)}"
+            f"Events scoring {lo}-{hi}: {len(bucket_events)} across "
+            f"{len(bucket_dtags)} datasets"
         )
+
+        bucket_root = pandda_dir / f"score_{lo}-{hi}"
+        bucket_processed = bucket_root / "processed_datasets"
+        analyses_dir = bucket_root / "analyses"
+
+        # Drop links left by an earlier run whose dataset no longer scores into
+        # this band, so the links cannot drift out of step with the events csv
+        # written below, and a dataset dropped from the PanDDA output does not
+        # leave a dangling link behind. Runs before the empty-bucket check so a
+        # band that has emptied is cleared rather than left stale. Only unlinks
+        # symlinks: that removes the link, never the processed_datasets dir it
+        # points at, and leaves any real file alone.
+        if bucket_processed.is_dir():
+            pruned = [
+                link.name
+                for link in bucket_processed.iterdir()
+                if link.name not in bucket_dtags and link.is_symlink()
+            ]
+            for name in pruned:
+                (bucket_processed / name).unlink()
+            if pruned:
+                logger.info(
+                    f"Pruned {len(pruned)} stale symlink(s) from {bucket_root.name}, "
+                    f"e.g. {sorted(pruned)[:5]}"
+                )
+
         if not bucket_dtags:
             continue
 
+        # Rank by score but keep a dtag's events together: order dtags by their
+        # best event in this bucket, then each dtag's own events by score.
+        bucket_events["dtag_best"] = bucket_events.groupby("dtag")["z_mean"].transform(
+            "max"
+        )
+        bucket_events = bucket_events.sort_values(
+            ["dtag_best", "dtag", "z_mean"], ascending=[False, True, False]
+        ).drop(columns="dtag_best")
+
         # Mirror the panddas layout: analyses/ and processed_datasets/ siblings
-        bucket_root = pandda_dir / f"score_{buckets[j]}-{buckets[j + 1]}"
-        bucket_processed = bucket_root / "processed_datasets"
-        analyses_dir = bucket_root / "analyses"
         bucket_processed.mkdir(parents=True, exist_ok=True)
         analyses_dir.mkdir(parents=True, exist_ok=True)
 
-        # Add this batch's datasets alongside any symlinked by previous runs
-        for dtag in bucket_dtags:
+        for dtag in sorted(bucket_dtags):
             safe_symlink(processed_dataset_dir / dtag, bucket_processed / dtag, logger)
 
-        # Filter the events csv on every dataset now in the bucket (this batch
-        # plus earlier ones) so prior batches stay represented.
-        all_bucket_dtags = [p.name for p in bucket_processed.iterdir()]
-        shutil.copy(sites_csv, analyses_dir)
-        filtered = df[df["dtag"].isin(all_bucket_dtags)].reset_index(drop=True)
-        filtered.to_csv(analyses_dir / "pandda_analyse_events.csv")
+        if sites_csv.exists():
+            shutil.copy(sites_csv, analyses_dir)
+        bucket_events.reset_index(drop=True).to_csv(
+            analyses_dir / "pandda_analyse_events.csv"
+        )
 
 
 def update_xchem_database(

--- a/src/dlstbx/util/xchem_collate_helpers.py
+++ b/src/dlstbx/util/xchem_collate_helpers.py
@@ -245,8 +245,7 @@ def symlink_score_buckets(
     Bucketing is per EVENT, not per dataset, so a dataset with events in more
     than one band is browsable under each. Every run rebuilds the view from the
     whole events csv, which is the complete picture of what PanDDA has
-    processed, so no dataset filter or cross-run accumulation is needed:
-    symlinks a re-analysis has moved to another band are pruned."""
+    processed."""
 
     processed_dataset_dir = panddas_dir / "processed_datasets"
     events_csv = panddas_dir / "analyses" / "pandda_analyse_events.csv"
@@ -259,8 +258,6 @@ def symlink_score_buckets(
     df = pd.read_csv(events_csv, index_col=0)
 
     for lo, hi in zip(buckets, buckets[1:]):
-        # `> lo` / `<= hi` keeps the bands contiguous across (0, 1]: an event
-        # landing exactly on a boundary goes to the lower band, not to neither.
         bucket_events = df[(df["z_mean"] > lo) & (df["z_mean"] <= hi)].copy()
         bucket_dtags = set(bucket_events["dtag"])
         logger.info(
@@ -274,11 +271,6 @@ def symlink_score_buckets(
 
         # Drop links left by an earlier run whose dataset no longer scores into
         # this band, so the links cannot drift out of step with the events csv
-        # written below, and a dataset dropped from the PanDDA output does not
-        # leave a dangling link behind. Runs before the empty-bucket check so a
-        # band that has emptied is cleared rather than left stale. Only unlinks
-        # symlinks: that removes the link, never the processed_datasets dir it
-        # points at, and leaves any real file alone.
         if bucket_processed.is_dir():
             pruned = [
                 link.name

--- a/src/dlstbx/wrapper/xchem_collate.py
+++ b/src/dlstbx/wrapper/xchem_collate.py
@@ -75,12 +75,14 @@ class XChemCollateWrapper(Wrapper):
             self.log.error(f"Could not prepare auto db for {processing_dir}: {e}")
             db_copy, updatable = None, None
 
-        if updatable is not None:
-            try:
-                symlink_score_buckets(panddas_dir, pandda_dir, updatable, self.log)
-            except Exception as e:
-                self.log.error(f"Exception bucketing scores for {panddas_dir}: {e}")
+        # Score bucketing reads only the PanDDA events csv, so it runs whether or
+        # not the soakDB copy could be prepared.
+        try:
+            symlink_score_buckets(panddas_dir, pandda_dir, self.log)
+        except Exception as e:
+            self.log.error(f"Exception bucketing scores for {panddas_dir}: {e}")
 
+        if updatable is not None:
             try:
                 update_xchem_database(
                     model_dir, pipedream_dir, panddas_dir, db_copy, updatable, self.log


### PR DESCRIPTION
Supports reprocessing legacy xchem visits by staging an existing `model_building` directory to be used in the hitidentification trigger. Produces json report detailing status of stageable and unstageable datasets.